### PR TITLE
Gave every WorldEntity a name and added add/get view 

### DIFF
--- a/src/semantic_world/connections.py
+++ b/src/semantic_world/connections.py
@@ -261,6 +261,7 @@ class Connection6DoF(PassiveConnection):
     """
 
     def __post_init__(self):
+        super().__post_init__()
         self.x = self.x or self._world.create_degree_of_freedom(name=PrefixedName('x', self.name))
         self.y = self.y or self._world.create_degree_of_freedom(name=PrefixedName('y', self.name))
         self.z = self.z or self._world.create_degree_of_freedom(name=PrefixedName('z', self.name))
@@ -333,23 +334,25 @@ class OmniDrive(ActiveConnection, PassiveConnection, HasUpdateState):
     rotation_velocity_limits: float = field(default=0.5)
 
     def __post_init__(self):
-        self.x = self.x or self._world.create_degree_of_freedom(name=PrefixedName('x', self.name))
-        self.y = self.y or self._world.create_degree_of_freedom(name=PrefixedName('y', self.name))
-        self.z = self.z or self._world.create_degree_of_freedom(name=PrefixedName('z', self.name))
+        super().__post_init__()
+        stringified_name = str(self.name)
+        self.x = self.x or self._world.create_degree_of_freedom(name=PrefixedName('x', stringified_name))
+        self.y = self.y or self._world.create_degree_of_freedom(name=PrefixedName('y', stringified_name))
+        self.z = self.z or self._world.create_degree_of_freedom(name=PrefixedName('z', stringified_name))
 
-        self.roll = self.roll or self._world.create_degree_of_freedom(name=PrefixedName('roll', self.name))
-        self.pitch = self.pitch or self._world.create_degree_of_freedom(name=PrefixedName('pitch', self.name))
+        self.roll = self.roll or self._world.create_degree_of_freedom(name=PrefixedName('roll', stringified_name))
+        self.pitch = self.pitch or self._world.create_degree_of_freedom(name=PrefixedName('pitch', stringified_name))
         self.yaw = self.yaw or self._world.create_degree_of_freedom(
-            name=PrefixedName('yaw', self.name),
+            name=PrefixedName('yaw', stringified_name),
             lower_limits={Derivatives.velocity: -self.rotation_velocity_limits},
             upper_limits={Derivatives.velocity: self.rotation_velocity_limits})
 
         self.x_vel = self.x_vel or self._world.create_degree_of_freedom(
-            name=PrefixedName('x_vel', self.name),
+            name=PrefixedName('x_vel', stringified_name),
             lower_limits={Derivatives.velocity: -self.translation_velocity_limits},
             upper_limits={Derivatives.velocity: self.translation_velocity_limits})
         self.y_vel = self.y_vel or self._world.create_degree_of_freedom(
-            name=PrefixedName('y_vel', self.name),
+            name=PrefixedName('y_vel', stringified_name),
             lower_limits={Derivatives.velocity: -self.translation_velocity_limits},
             upper_limits={Derivatives.velocity: self.translation_velocity_limits})
         self.active_dofs = [self.x_vel, self.y_vel, self.yaw]

--- a/src/semantic_world/degree_of_freedom.py
+++ b/src/semantic_world/degree_of_freedom.py
@@ -22,11 +22,6 @@ class DegreeOfFreedom(WorldEntity):
     and provides methods to get and set limits for these derivatives.
     """
 
-    name: PrefixedName
-    """
-    The identifier for this free variable
-    """
-
     _lower_limits: Dict[Derivatives, Optional[float]] = field(default=None)
     _upper_limits: Dict[Derivatives, Optional[float]] = field(default=None)
     """

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -406,6 +406,51 @@ class World:
         connection._world = self
         self.kinematic_structure.add_edge(connection.parent.index, connection.child.index, connection)
 
+    def add_view(self, view: View) -> None:
+        """
+        Adds a view to the current list of views if it doesn't already exist. Ensures
+        that the `view` is associated with the current instance and maintains the
+        integrity of unique view names.
+
+        :param view: The view instance to be added. Its name must be unique within
+            the current context.
+
+        :raises ValueError: If a view with the same name already exists.
+        """
+        try:
+            self.get_view_by_name(view.name)
+        except ValueError:
+            pass
+        else:
+            raise ValueError(f"View with name {view.name} already exists.")
+        view._world = self
+        self.views.append(view)
+
+    def get_view_by_name(self, name: Union[str, PrefixedName]) -> View:
+        """
+        Retrieves a View from the list of view based on its name.
+        If the input is of type `PrefixedName`, it checks whether the prefix is specified and looks for an
+        exact match. Otherwise, it matches based on the name's string representation.
+        If more than one body with the same name is found, an assertion error is raised.
+        If no matching body is found, a `ValueError` is raised.
+
+        :param name: The name of the view to search for. Can be a string or a `PrefixedName` object.
+        :return: The `View` object that matches the given name.
+        :raises ValueError: If multiple or no views with the specified name are found.
+        """
+        if isinstance(name, PrefixedName):
+            if name.prefix is not None:
+                matches = [view for view in self.views if view.name == name]
+            else:
+                matches = [view for view in self.views if view.name.name == name.name]
+        else:
+            matches = [view for view in self.views if view.name.name == name]
+        if len(matches) > 1:
+            raise ValueError(f'Multiple views with name {name} found')
+        if matches:
+            return matches[0]
+        raise ValueError(f'View with name {name} not found')
+
     @modifies_world
     def remove_body(self, body: Body) -> None:
         if body._world is self and body.index is not None:

--- a/src/semantic_world/world_entity.py
+++ b/src/semantic_world/world_entity.py
@@ -32,18 +32,17 @@ class WorldEntity:
     The views this entity is part of.
     """
 
+    name: PrefixedName = field(default=None, kw_only=True)
+    """
+    The identifier for this world entity.
+    """
+
 
 @dataclass
 class Body(WorldEntity):
     """
     Represents a body in the world.
     A body is a semantic atom, meaning that it cannot be decomposed into meaningful smaller parts.
-    """
-
-    name: PrefixedName
-    """
-    The name of the link. Must be unique in the world.
-    If not provided, a unique name will be generated.
     """
 
     visual: List[Shape] = field(default_factory=list, repr=False)
@@ -114,7 +113,7 @@ class Body(WorldEntity):
         """
         Creates a new link from an existing link.
         """
-        new_link = cls(body.name, body.visual, body.collision)
+        new_link = cls(name=body.name, visual=body.visual, collision=body.collision)
         new_link._world = body._world
         new_link.index = body.index
         return new_link
@@ -157,7 +156,7 @@ class Connection(WorldEntity):
     The child body of the connection.
     """
 
-    origin_expression: TransformationMatrix = None
+    origin_expression: TransformationMatrix = field(default=None)
     """
     A symbolic expression describing the origin of the connection.
     """
@@ -167,16 +166,14 @@ class Connection(WorldEntity):
             self.origin_expression = TransformationMatrix()
         self.origin_expression.reference_frame = self.parent.name
         self.origin_expression.child_frame = self.child.name
+        if self.name is None:
+            self.name = PrefixedName(f'{self.parent.name.name}_T_{self.child.name.name}', prefix=self.child.name.prefix)
 
     def __hash__(self):
         return hash((self.parent, self.child))
 
     def __eq__(self, other):
         return self.name == other.name
-
-    @property
-    def name(self):
-        return PrefixedName(f'{self.parent.name.name}_T_{self.child.name.name}', prefix=self.child.name.prefix)
 
     @property
     def origin(self) -> NpMatrix4x4:

--- a/test/test_orm/test_orm.py
+++ b/test/test_orm/test_orm.py
@@ -65,7 +65,7 @@ class ORMTest(unittest.TestCase):
         color = Color(0., 1., 1.)
         shape1 = Box(origin=origin, scale=scale, color=color)
         b1 = Body(
-            PrefixedName("b1"),
+            name=PrefixedName("b1"),
             collision=[shape1]
         )
 

--- a/test/test_worlds/test_world.py
+++ b/test/test_worlds/test_world.py
@@ -3,33 +3,35 @@ from typing import Tuple
 import numpy as np
 import pytest
 
-from semantic_world.connections import PrismaticConnection, RevoluteConnection, Connection6DoF, FixedConnection
+from semantic_world.connections import PrismaticConnection, RevoluteConnection, Connection6DoF, FixedConnection, \
+    UnitVector
 from semantic_world.prefixed_name import PrefixedName
 from semantic_world.spatial_types.derivatives import Derivatives
 from semantic_world.spatial_types.math import rotation_matrix_from_rpy
 from semantic_world.spatial_types.symbol_manager import symbol_manager
 from semantic_world.world import World, Body
+from semantic_world.world_entity import View
 
 
 @pytest.fixture
 def world_setup() -> Tuple[World, Body, Body, Body, Body, Body]:
     world = World()
-    root = Body(PrefixedName(name='root', prefix='world'))
-    l1 = Body(PrefixedName('l1'))
-    l2 = Body(PrefixedName('l2'))
-    bf = Body(PrefixedName('bf'))
-    r1 = Body(PrefixedName('r1'))
-    r2 = Body(PrefixedName('r2'))
+    root = Body(name=PrefixedName(name='root', prefix='world'))
+    l1 = Body(name=PrefixedName('l1'))
+    l2 = Body(name=PrefixedName('l2'))
+    bf = Body(name=PrefixedName('bf'))
+    r1 = Body(name=PrefixedName('r1'))
+    r2 = Body(name=PrefixedName('r2'))
 
     with world.modify_world():
         [world.add_body(b) for b in [root, l1, l2, bf, r1, r2]]
         dof = world.create_degree_of_freedom(name=PrefixedName('dof'), lower_limits={Derivatives.velocity: -1},
                                              upper_limits={Derivatives.velocity: 1})
 
-        c_l1_l2 = PrismaticConnection(l1, l2, dof=dof, axis=(1, 0, 0))
-        c_r1_r2 = RevoluteConnection(r1, r2, dof=dof, axis=(0, 0, 1))
-        bf_root_l1 = FixedConnection(bf, l1)
-        bf_root_r1 = FixedConnection(bf, r1)
+        c_l1_l2 = PrismaticConnection(parent=l1, child=l2, dof=dof, axis=UnitVector(1, 0, 0))
+        c_r1_r2 = RevoluteConnection(parent=r1, child=r2, dof=dof, axis=UnitVector(0, 0, 1))
+        bf_root_l1 = FixedConnection(parent=bf, child=l1)
+        bf_root_r1 = FixedConnection(parent=bf, child=r1)
         world.add_connection(c_l1_l2)
         world.add_connection(c_r1_r2)
         world.add_connection(bf_root_l1)
@@ -211,3 +213,11 @@ def test_apply_control_commands(world_setup):
     assert world.state[connection.dof.name].acceleration == 100. * dt
     assert world.state[connection.dof.name].velocity == 100. * dt * dt
     assert world.state[connection.dof.name].position == 100. * dt * dt * dt
+
+def test_add_view(world_setup):
+    world, l1, l2, bf, r1, r2 = world_setup
+    v = View(name=PrefixedName('muh'))
+    world.add_view(v)
+    with pytest.raises(ValueError):
+        world.add_view(v)
+    assert world.get_view_by_name(v.name) == v

--- a/test/test_worlds/test_world_pr2.py
+++ b/test/test_worlds/test_world_pr2.py
@@ -20,7 +20,7 @@ def pr2_world():
     pr2 = os.path.join(urdf_dir, "pr2_kinematic_tree.urdf")
     world = World()
     with world.modify_world():
-        localization_body = Body(PrefixedName('odom_combined'))
+        localization_body = Body(name=PrefixedName('odom_combined'))
         world.add_body(localization_body)
 
         pr2_parser = URDFParser(pr2)
@@ -160,8 +160,7 @@ def test_compute_ik_unreachable(pr2_world):
         pr2_world.compute_inverse_kinematics(bf, eef, fk)
 
 def test_apply_control_commands_omni_drive_pr2(pr2_world):
-    omni_drive: OmniDrive = pr2_world.get_connection_by_name(
-        PrefixedName(name='odom_combined_T_base_footprint', prefix='pr2_kinematic_tree'))
+    omni_drive: OmniDrive = pr2_world.get_connection_by_name('odom_combined_T_base_footprint')
     cmd = np.zeros((len(pr2_world.degrees_of_freedom)), dtype=float)
     cmd[-3] = 100
     cmd[-2] = 100


### PR DESCRIPTION
I noticed that basically every world entity subclass has a name, while I was creating new views. So why not simply give every entity a name?

without a name it is also quite difficult to retrieve a view from the world 