### PR TITLE
proper latex math formatting for style guide

### DIFF
--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -22,7 +22,7 @@ Prevents frame confusion errors and makes transformation chains self-documenting
 ### Transforms
 Transformations are represented using homogeneous transformation matrices.
 The 4x4 matrix $_{root}T_{tip}$ refers to the transformation matrix to transform things from frame/body $tip$ to frame/body $root$, or the pose for $tip$ relative to $root$, with:
-```math
+```{math}
 {_{root}T_{tip}} = \begin{bmatrix}
 	r_{0,0} & r_{0,1} & r_{0,2} & x \\
 	r_{1,0} & r_{1,1} & r_{1,2} & y \\
@@ -34,7 +34,7 @@ In code please use `root_T_tip` to refer to such matrices.
 
 ### Rotation matrices
 Rotation matrices are also represented as 4x4 matrices, where the translation component is 0.
-```math
+```{math}
 {_{root}R_{tip}} =\begin{bmatrix}
 	r_{0,0} & r_{0,1} & r_{0,2} & 0 \\
 	r_{1,0} & r_{1,1} & r_{1,2} & 0 \\
@@ -47,7 +47,7 @@ In code please use `root_R_tip`.
 
 ### Points
 Points are represented as 4d vectors:
-```math
+```{math}
 {_{root}P_{tip}} =\begin{bmatrix}
 	x \\
 	y \\
@@ -59,7 +59,7 @@ In code please use `root_P_tip`.
 
 ### Vectors
 Vectors are represented as 4d vectors:
-```math
+```{math}
 {_{root}V_{tip}} =\begin{bmatrix}
 	x \\
 	y \\
@@ -79,20 +79,20 @@ map_T_base_link
 Following this notation prevents most trivial transformation mistakes.
 When transforming things from one frame to another, make sure that the "inner" frame names match:
 
-#### Transform poses
+### Transform poses
 Transforms pose1 from frame b to frame a.
 ```python
 a_T_pose1 = a_T_b @ b_T_pose1  
 ```
 
-#### Combine multiple transformations
+### Combine multiple transformations
 ```python
 a_T_c = a_T_b @ b_T_c 
 ```
 
-#### Invert transformations
+### Invert transformations
 ```python
-from semantic_world.spatial_types.math import inverse_frame
+from semantic_world.spatial_types.{math import inverse_frame}
 c_T_a = inverse_frame(a_T_c)
 ```
 Remember that:
@@ -100,25 +100,25 @@ Remember that:
 a_T_c.T != inverse_frame(a_T_c)
 ```
 
-#### Combine rotation matrices and transformations
+### Combine rotation matrices and transformations
 ```python
 a_R_r = a_T_b @ b_R_r
-a_R_r = a_R_b @ b_R_r  #rotation matrices don't care about translation, so these to are equivalent
+a_R_r = a_R_b @ b_R_r  #rotation matrices don't care about translation, so these two are equivalent
 ```
 
-#### Invert rotation matrices
+### Invert rotation matrices
 ```python
-from semantic_world.spatial_types.math import inverse_frame
+from semantic_world.spatial_types.{math import inverse_frame}
 b_R_a = inverse_frame(a_R_b)
 b_R_a = a_R_b.T  # for rotation matrices only, the transpose is equal to its inverse.
 ```
 
-#### Transform points
+### Transform points
 ```python
 a_P_p1 = a_T_b @ b_P_p1
 ```
 
-#### Rotating points
+### Rotating points
 Rotating points is weird and could mean that you are doing something wrong.
 When you rotate a point, it means you are trying to move the point somewhere else, thus creating a new point.
 ```python
@@ -127,31 +127,31 @@ a_P_p2 = a_R_b @ b_P_p1
 This is conceptually different from transforming, because there the point stays at the same place, just expressed relative to a different frame.
 
 
-#### Transform Vectors
+### Transform Vectors
 ```python
 a_V_v1 = a_T_b @ b_V_v1
 a_V_v1 = a_R_b @ b_V_v1  # a vector only expresses a direction, it has no fixed place in space, therefore applying a full transformation or only a rotation results in the same vector.
 ```
 
-#### Subtract points to automatically get a vector
+### Subtract points to automatically get a vector
 You must ensure that the two points are represented relative to the same reference frame, notice that both have "a" on the left.
 Since the last entires for points are 1, the subtraction will automatically have a 0 as 4th entries, which represents a vector.
 ```python
 a_V_error = a_P_p2 - a_P_p1 
 ```
 
-#### Adding points
+### Adding points
 Make sure that this is actually what you are trying to do, because it doesn't make geometric sense.
 The result of such an addition will have "2" as the 4th entry and is not a valid point anymore.
 
-#### Adding vectors
+### Adding vectors
 You must ensure that both vectors are represented relative to the same reference frame.
 This is possible, as the 4th entry remains 0.
 ```python
 a_V_v3 = a_V_v1 + a_V_v2
 ```
 
-#### Translating points with vectors
+### Translating points with vectors
 You must ensure that both vectors are represented relative to the same reference frame.
 ```python
 a_P_p3 = a_P_p1 + a_V_v3

--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -92,7 +92,7 @@ a_T_c = a_T_b @ b_T_c
 
 ### Invert transformations
 ```python
-from semantic_world.spatial_types.{math import inverse_frame}
+from semantic_world.spatial_types.math import inverse_frame
 c_T_a = inverse_frame(a_T_c)
 ```
 Remember that:
@@ -108,7 +108,7 @@ a_R_r = a_R_b @ b_R_r  #rotation matrices don't care about translation, so these
 
 ### Invert rotation matrices
 ```python
-from semantic_world.spatial_types.{math import inverse_frame}
+from semantic_world.spatial_types.math import inverse_frame
 b_R_a = inverse_frame(a_R_b)
 b_R_a = a_R_b.T  # for rotation matrices only, the transpose is equal to its inverse.
 ```


### PR DESCRIPTION
the latex code is now correctly formatted in the transformation matrix style guide