### PR TITLE
Merge pose

### DIFF
--- a/src/semantic_world/testing.py
+++ b/src/semantic_world/testing.py
@@ -83,8 +83,8 @@ def pr2_world():
         world_with_pr2 = pr2_parser.parse()
         # world_with_pr2.plot_kinematic_structure()
         pr2_root = world_with_pr2.root
-        world.merge_world(world_with_pr2)
         c_root_bf = OmniDrive(parent=localization_body, child=pr2_root, _world=world)
-        world.add_connection(c_root_bf)
+        world.merge_world(world_with_pr2, c_root_bf)
+
     return world
 

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -494,6 +494,18 @@ class World:
         connection = partial_connection or Connection6DoF(parent=self_root, child=other_root, _world=self)
         self.add_connection(connection)
 
+    def merge_world_with_pose(self, other: World, pose: NpMatrix4x4) -> None:
+        """
+        Merge another world into the existing one, creates a 6DoF connection between the root of this world and the root
+        of the other world.
+        :param other: The world to be added.
+        :param pose: The pose of the other world in this world's coordinate system.
+        """
+        root_connection = Connection6DoF(parent=self.root, child=other.root, _world=self)
+        root_connection.origin = pose
+        self.merge_world(other, root_connection)
+        self.add_connection(root_connection)
+
     def __str__(self):
         return f"{self.__class__.__name__} with {len(self.bodies)} bodies."
 

--- a/test/test_worlds/test_world.py
+++ b/test/test_worlds/test_world.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
-from functools import partial
-from semantic_world.connections import PrismaticConnection, RevoluteConnection, Connection6DoF, FixedConnection, \
-    UnitVector
+
+from semantic_world.connections import PrismaticConnection, RevoluteConnection, Connection6DoF
 from semantic_world.prefixed_name import PrefixedName
 from semantic_world.spatial_types.derivatives import Derivatives
 from semantic_world.spatial_types.math import rotation_matrix_from_rpy
@@ -199,23 +198,26 @@ def test_compute_relative_pose(world_setup):
 
     np.testing.assert_array_almost_equal(relative_pose, expected_pose)
 
+
 def test_compute_relative_pose_both(world_setup):
     world, l1, l2, bf, r1, r2 = world_setup
     world.get_connection(world.root, bf).origin = np.array([[0., -1., 0., 1.],
-                                                        [1., 0., 0., 0.],
-                                                        [0., 0., 1., 0.],
-                                                        [0., 0., 0., 1.]])
+                                                            [1., 0., 0., 0.],
+                                                            [0., 0., 1., 0.],
+                                                            [0., 0., 0., 1.]])
     world.notify_state_change()
 
     pose = np.eye(4)
     pose[0, 3] = 1.0  # Translate along x-axis
     relative_pose = world.compute_relative_pose(pose, world.root, bf)
+    # Rotation is 90 degrees around z-axis, translation is 1 along x-axis
     expected_pose = np.array([[0., -1., 0., 1.],
                               [1., 0., 0., 1.],
                               [0., 0., 1., 0.],
                               [0., 0., 0., 1.]])
 
     np.testing.assert_array_almost_equal(relative_pose, expected_pose)
+
 
 def test_compute_relative_pose_only_translation(world_setup):
     world, l1, l2, bf, r1, r2 = world_setup
@@ -233,6 +235,7 @@ def test_compute_relative_pose_only_translation(world_setup):
 
     np.testing.assert_array_almost_equal(relative_pose, expected_pose)
 
+
 def test_compute_relative_pose_only_rotation(world_setup):
     world, l1, l2, bf, r1, r2 = world_setup
     connection: RevoluteConnection = world.get_connection(r1, r2)
@@ -248,6 +251,7 @@ def test_compute_relative_pose_only_rotation(world_setup):
 
     np.testing.assert_array_almost_equal(relative_pose, expected_pose)
 
+
 def test_add_view(world_setup):
     world, l1, l2, bf, r1, r2 = world_setup
     v = View(name=PrefixedName('muh'))
@@ -255,6 +259,7 @@ def test_add_view(world_setup):
     with pytest.raises(ValueError):
         world.add_view(v)
     assert world.get_view_by_name(v.name) == v
+
 
 def test_merge_world(world_setup, pr2_world):
     world, l1, l2, bf, r1, r2 = world_setup
@@ -274,6 +279,7 @@ def test_merge_world(world_setup, pr2_world):
     assert torso_lift_link._world == world
     assert r_shoulder_pan_joint._world == world
 
+
 def test_merge_with_connection(world_setup, pr2_world):
     world, l1, l2, bf, r1, r2 = world_setup
 
@@ -291,3 +297,51 @@ def test_merge_with_connection(world_setup, pr2_world):
     assert new_connection in world.connections
     assert torso_lift_link._world == world
     assert r_shoulder_pan_joint._world == world
+
+
+def test_merge_with_pose(world_setup, pr2_world):
+    world, l1, l2, bf, r1, r2 = world_setup
+
+    base_link = pr2_world.get_body_by_name("base_link")
+    r_gripper_tool_frame = pr2_world.get_body_by_name('r_gripper_tool_frame')
+    torso_lift_link = pr2_world.get_body_by_name("torso_lift_link")
+    r_shoulder_pan_joint = pr2_world.get_connection(torso_lift_link, pr2_world.get_body_by_name("r_shoulder_pan_link"))
+
+    pose = np.eye(4)
+    pose[0, 3] = 1.0  # Translate along x-axis
+
+    world.merge_world_with_pose(pr2_world, pose)
+
+    assert base_link in world.bodies
+    assert r_gripper_tool_frame in world.bodies
+    assert torso_lift_link._world == world
+    assert r_shoulder_pan_joint._world == world
+    assert world.compute_forward_kinematics_np(world.root, base_link)[0, 3] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_merge_with_pose_rotation(world_setup, pr2_world):
+    world, l1, l2, bf, r1, r2 = world_setup
+
+    base_link = pr2_world.get_body_by_name("base_link")
+    r_gripper_tool_frame = pr2_world.get_body_by_name('r_gripper_tool_frame')
+    torso_lift_link = pr2_world.get_body_by_name("torso_lift_link")
+    r_shoulder_pan_joint = pr2_world.get_connection(torso_lift_link, pr2_world.get_body_by_name("r_shoulder_pan_link"))
+    base_footprint = pr2_world.get_body_by_name("base_footprint")
+
+    # Rotation is 90 degrees around z-axis, translation is 1 along x-axis
+    pose = np.array([[0., -1., 0., 1.],
+                     [1., 0., 0., 1.],
+                     [0., 0., 1., 0.],
+                     [0., 0., 0., 1.]])
+
+    world.merge_world_with_pose(pr2_world, pose)
+
+    assert base_link in world.bodies
+    assert r_gripper_tool_frame in world.bodies
+    assert torso_lift_link._world == world
+    assert r_shoulder_pan_joint._world == world
+    fk_base = world.compute_forward_kinematics_np(world.root, base_footprint)
+    assert fk_base[0, 3] == pytest.approx(1.0, abs=1e-6)
+    assert fk_base[1, 3] == pytest.approx(1.0, abs=1e-6)
+    assert fk_base[2, 3] == pytest.approx(0.0, abs=1e-6)
+    np.testing.assert_array_almost_equal(rotation_matrix_from_rpy(0, 0, np.pi / 2)[:3, :3], fk_base[:3, :3], decimal=6)


### PR DESCRIPTION
# Description
This PR fixes the merge_worlds method by creating a connection between the roots of both world thus resulting in a valid world model. (Feedback on the signatur of merge_worlds is appriciated, we could also  do merge_worlds(self, other, self_mount_body, connection_class))


It also adds a method merge_worlds_with_pose which merges both worlds and creates a 6DOF connection with the pose as origin. 