### PR TITLE
[View Factories] Factories for creating views based on input parameters

### DIFF
--- a/examples/graph_of_convex_sets.md
+++ b/examples/graph_of_convex_sets.md
@@ -145,8 +145,8 @@ This allows the accessing of locations using a sequence of local problems put to
 Finally, let's find a way from here to there:
 
 ```{code-cell} ipython2
-start = Point3(-0.75, 0, 0.15)
-goal = Point3(0.75, 0, 0.15)
+start = Point3(-0.75, 0, 1.15)
+goal = Point3(0.75, 0, 1.15)
 path = gcs.path_from_to(start, goal)
 print("A potential path is", [(point.x, point.y, point.z) for point in path])
 ```

--- a/src/semantic_world/adapters/viz_marker.py
+++ b/src/semantic_world/adapters/viz_marker.py
@@ -67,7 +67,7 @@ class VizMarkerPublisher:
                 msg.ns = body.name.name
                 msg.id = i
                 msg.action = Marker.ADD
-                msg.pose = self.transform_to_pose(self.world.compute_forward_kinematics_np(self.world.root, body) @ collision.origin.to_np())
+                msg.pose = self.transform_to_pose((self.world.compute_forward_kinematics(self.world.root, body) @ collision.origin).to_np())
                 msg.color = body.color if isinstance(body, Primitive) else ColorRGBA(r=1.0, g=1.0, b=1.0, a=1.0)
                 msg.lifetime = Duration(sec=1)
 

--- a/src/semantic_world/geometry.py
+++ b/src/semantic_world/geometry.py
@@ -100,14 +100,18 @@ class Shape(ABC):
 
         if reference_frame_world is not None:
             reference_T_origin: TransformationMatrix = reference_frame_world.compute_forward_kinematics(reference_frame,
-                                                                                           origin_frame)
+                                                                                                        origin_frame)
         else:
             reference_T_origin: TransformationMatrix = TransformationMatrix()
 
         reference_T_self: TransformationMatrix = reference_T_origin @ origin_T_self
 
         # Get all 8 corners of the BB in link-local space
-        list_self_T_corner = [TransformationMatrix.from_point_rotation_matrix(self_P_corner) for self_P_corner in self._local_bounding_box().get_points()] # shape (8, 3)
+        list_self_T_corner = [
+            TransformationMatrix.from_point_rotation_matrix(self_P_corner)
+            for self_P_corner
+            in self._local_bounding_box().get_points()
+        ] # shape (8, 3)
 
         list_reference_T_corner = [reference_T_self @ self_T_corner for self_T_corner in list_self_T_corner]
 
@@ -546,7 +550,7 @@ class BoundingBoxCollection:
                                          simple_event[SpatialVariables.z.value].simple_sets):
 
             bb = BoundingBox(x.lower, y.lower, z.lower, x.upper, y.upper, z.upper)
-            if not keep_surface and bb.depth == 0 or bb.height == 0 or bb.width == 0:
+            if not keep_surface and (bb.depth == 0 or bb.height == 0 or bb.width == 0):
                 continue
             result.append(bb)
         return BoundingBoxCollection(result)

--- a/src/semantic_world/graph_of_convex_sets.py
+++ b/src/semantic_world/graph_of_convex_sets.py
@@ -253,13 +253,15 @@ class GraphOfConvexSets:
             else:
                 return bb.bloat(0, bloat_walls, 0.01)
 
+        world_root = list(obstacle_view.bodies)[0]._world.root
+
         bloated_obstacles: BoundingBoxCollection = BoundingBoxCollection([
-            bloat_obstacle(bb) for bb in obstacle_view.as_bounding_box_collection()
+            bloat_obstacle(bb) for bb in obstacle_view.as_bounding_box_collection(world_root)
         ])
 
         if wall_view is not None:
             bloated_walls: BoundingBoxCollection = BoundingBoxCollection([
-                bloat_wall(bb) for bb in wall_view.as_bounding_box_collection()
+                bloat_wall(bb) for bb in wall_view.as_bounding_box_collection(world_root)
             ])
             bloated_obstacles.merge(bloated_walls)
 

--- a/src/semantic_world/variables.py
+++ b/src/semantic_world/variables.py
@@ -19,3 +19,11 @@ class SpatialVariables(Enum):
     @classproperty
     def xy(cls):
         return SortedSet([cls.x.value, cls.y.value])
+
+    @classproperty
+    def xz(cls):
+        return SortedSet([cls.x.value, cls.z.value])
+
+    @classproperty
+    def yz(cls):
+        return SortedSet([cls.y.value, cls.z.value])

--- a/src/semantic_world/views/factories.py
+++ b/src/semantic_world/views/factories.py
@@ -183,12 +183,6 @@ class ContainerFactory(ViewFactory[Container]):
 
         return inner_event
 
-
-class Alignment(IntEnum):
-    HORIZONTAL = 0
-    VERTICAL = 1
-
-
 @dataclass
 class HandleFactory(ViewFactory[Handle]):
     """
@@ -633,7 +627,7 @@ class DresserFactory(ViewFactory[Dresser]):
             drawers=[drawer for drawer in dresser_world.get_views_by_type(Drawer)],
             doors=[door for door in dresser_world.get_views_by_type(Door)],
         )
-        dresser_world.add_view(dresser_view)
+        dresser_world.add_view(dresser_view, exists_ok=True)
 
         return dresser_world
 

--- a/src/semantic_world/views/factories.py
+++ b/src/semantic_world/views/factories.py
@@ -918,6 +918,15 @@ class WallFactory(ViewFactory[Wall]):
 def add_door_to_world(
     door_factory: DoorFactory, parent_T_door: TransformationMatrix, parent_world: World
 ):
+    """
+    Adds a door to the parent world with a revolute connection. The Door's pivot point is on the opposite side of the
+    handle.
+
+    :param door_factory: The factory used to create the door.
+    :param parent_T_door: The transformation matrix defining the door's position and orientation relative
+    to the parent world.
+    :param parent_world: The world to which the door will be added.
+    """
     door_world = door_factory.create()
 
     door_view: Door = door_world.get_views_by_type(Door)[0]
@@ -962,6 +971,16 @@ def add_door_to_world(
 def calculate_door_pivot_point(
     door_view, door_transform: TransformationMatrix, scale: Scale
 ) -> TransformationMatrix:
+    """
+    Calculate the door pivot point based on the handle position and the door scale. The pivot point is on the opposite
+    side of the handle.
+
+    :param door_view: The door view containing the handle.
+    :param door_transform: The transformation matrix defining the door's position and orientation.
+    :param scale: The scale of the door.
+
+    :return: The transformation matrix defining the door's pivot point.
+    """
     parent_connection = door_view.handle.body.parent_connection
     if parent_connection is None:
         raise ValueError(

--- a/src/semantic_world/views/factories.py
+++ b/src/semantic_world/views/factories.py
@@ -1,0 +1,1058 @@
+import re
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import TypeVar, Generic
+
+from numpy import ndarray
+from random_events.interval import Bound
+from random_events.product_algebra import *
+
+from semantic_world.connections import (
+    PrismaticConnection,
+    FixedConnection,
+    RevoluteConnection,
+)
+from semantic_world.degree_of_freedom import DegreeOfFreedom
+from semantic_world.geometry import Scale, BoundingBoxCollection, Box
+from semantic_world.prefixed_name import PrefixedName
+from semantic_world.spatial_types.derivatives import DerivativeMap
+from semantic_world.spatial_types.spatial_types import (
+    TransformationMatrix,
+    Vector3,
+    Point3,
+)
+from semantic_world.utils import IDGenerator
+from semantic_world.variables import SpatialVariables
+from semantic_world.views import (
+    Container,
+    Handle,
+    Dresser,
+    Drawer,
+    Door,
+    Wall,
+    DoubleDoor,
+)
+from semantic_world.world import World
+from semantic_world.world_entity import Body
+
+id_generator = IDGenerator()
+
+
+class Direction(IntEnum):
+    X = 0
+    Y = 1
+    Z = 2
+    NEGATIVE_X = 3
+    NEGATIVE_Y = 4
+    NEGATIVE_Z = 5
+
+
+def event_from_scale(scale: Scale):
+    return SimpleEvent(
+        {
+            SpatialVariables.x.value: closed(-scale.x / 2, scale.x / 2),
+            SpatialVariables.y.value: closed(-scale.y / 2, scale.y / 2),
+            SpatialVariables.z.value: closed(-scale.z / 2, scale.z / 2),
+        }
+    )
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class ViewFactory(Generic[T], ABC):
+    """
+    Abstract factory for the creation of worlds containing a single view of type T.
+    """
+
+    @abstractmethod
+    def create(self) -> World:
+        """
+        Create the world containing a view of type T.
+        :return: The world.
+        """
+        raise NotImplementedError()
+
+
+@dataclass
+class ContainerFactory(ViewFactory[Container]):
+    """
+    Factory for creating a container with walls of a specified thickness and its opening in direction.
+    """
+
+    name: PrefixedName
+    """
+    The name of the container.
+    """
+
+    scale: Scale = field(default_factory=lambda: Scale(1.0, 1.0, 1.0))
+    """
+    The scale of the container, defining its size in the world.
+    """
+
+    wall_thickness: float = 0.05
+    """
+    The thickness of the walls of the container.
+    """
+
+    direction: Direction = Direction.X
+    """
+    The direction in which the container is open.
+    """
+
+    def create(self) -> World:
+        """
+        Return a world with a container body at its root.
+        """
+
+        container_event = self.create_container_event()
+
+        container_body = Body(name=self.name)
+        collision_shapes = BoundingBoxCollection.from_event(container_event).as_shapes(
+            container_body
+        )
+        container_body.collision = collision_shapes
+        container_body.visual = collision_shapes
+
+        container_view = Container(body=container_body, name=self.name)
+
+        world = World()
+        world.add_body(container_body)
+        world.add_view(container_view)
+
+        return world
+
+    def create_container_event(self) -> Event:
+        """
+        Return an event representing a container with walls of a specified thickness.
+        """
+        outer_box = event_from_scale(self.scale)
+        inner_scale = Scale(
+            self.scale.x - self.wall_thickness,
+            self.scale.y - self.wall_thickness,
+            self.scale.z - self.wall_thickness,
+        )
+        inner_box = event_from_scale(inner_scale)
+
+        inner_box = self.extend_inner_event_in_direction(
+            inner_event=inner_box, inner_scale=inner_scale
+        )
+
+        container_event = outer_box.as_composite_set() - inner_box.as_composite_set()
+
+        return container_event
+
+    def extend_inner_event_in_direction(
+        self, inner_event: SimpleEvent, inner_scale: Scale
+    ) -> SimpleEvent:
+        """
+        Extend the inner event in the specified direction to create the container opening in that direction.
+
+        :param inner_event: The inner event representing the inner box.
+        :param inner_scale: The scale of the inner box used how far to extend the inner event.
+
+        :return: The modified inner event with the specified direction extended.
+        """
+
+        match self.direction:
+            case Direction.X:
+                inner_event[SpatialVariables.x.value] = closed(
+                    -inner_scale.x / 2, self.scale.x / 2
+                )
+            case Direction.Y:
+                inner_event[SpatialVariables.y.value] = closed(
+                    -inner_scale.y / 2, self.scale.y / 2
+                )
+            case Direction.Z:
+                inner_event[SpatialVariables.z.value] = closed(
+                    -inner_scale.z / 2, self.scale.z / 2
+                )
+            case Direction.NEGATIVE_X:
+                inner_event[SpatialVariables.x.value] = closed(
+                    -self.scale.x / 2, inner_scale.x / 2
+                )
+            case Direction.NEGATIVE_Y:
+                inner_event[SpatialVariables.y.value] = closed(
+                    -self.scale.y / 2, inner_scale.y / 2
+                )
+            case Direction.NEGATIVE_Z:
+                inner_event[SpatialVariables.z.value] = closed(
+                    -self.scale.z / 2, inner_scale.z / 2
+                )
+
+        return inner_event
+
+
+class Alignment(IntEnum):
+    HORIZONTAL = 0
+    VERTICAL = 1
+
+
+@dataclass
+class HandleFactory(ViewFactory[Handle]):
+    """
+    Factory for creating a handle with a specified scale and thickness.
+    The handle is represented as a box with an inner cutout to create the handle shape.
+    """
+
+    name: PrefixedName
+    """
+    The name of the handle.
+    """
+
+    scale: Scale = field(default_factory=lambda: Scale(0.05, 0.1, 0.02))
+    """
+    The scale of the handle.
+    """
+
+    thickness: float = 0.01
+    """
+    Thickness of the handle bar.
+    """
+
+    def create(self) -> World:
+        """
+        Create a world with a handle body at its root.
+        """
+
+        handle_event = self.create_handle_event()
+
+        handle = Body(name=self.name)
+        collision = BoundingBoxCollection.from_event(handle_event).as_shapes(handle)
+        handle.collision = collision
+        handle.visual = collision
+
+        handle_view = Handle(name=self.name, body=handle)
+
+        world = World()
+        world.add_body(handle)
+        world.add_view(handle_view)
+        return world
+
+    def create_handle_event(self) -> Event:
+        """
+        Return an event representing a handle.
+        """
+
+        handle_event = self.create_outer_box_event().as_composite_set()
+
+        inner_box = self.create_inner_box_event().as_composite_set()
+
+        handle_event -= inner_box
+
+        return handle_event
+
+    def create_outer_box_event(self) -> SimpleEvent:
+        """
+        Return an event representing the main body of a handle.
+        """
+        x_interval = closed(0, self.scale.x)
+        y_interval = closed(-self.scale.y / 2, self.scale.y / 2)
+        z_interval = closed(-self.scale.z / 2, self.scale.z / 2)
+
+        handle_event = SimpleEvent(
+            {
+                SpatialVariables.x.value: x_interval,
+                SpatialVariables.y.value: y_interval,
+                SpatialVariables.z.value: z_interval,
+            }
+        )
+
+        return handle_event
+
+    def create_inner_box_event(self) -> SimpleEvent:
+        """
+        Return an event used to cut out the inner part of the handle.
+        """
+        x_interval = closed(0, self.scale.x - self.thickness)
+        y_interval = closed(
+            -self.scale.y / 2 + self.thickness, self.scale.y / 2 - self.thickness
+        )
+        z_interval = closed(-self.scale.z, self.scale.z)
+
+        inner_box = SimpleEvent(
+            {
+                SpatialVariables.x.value: x_interval,
+                SpatialVariables.y.value: y_interval,
+                SpatialVariables.z.value: z_interval,
+            }
+        )
+
+        return inner_box
+
+
+@dataclass
+class DoorFactory(ViewFactory[Door]):
+    """
+    Factory for creating a door with a handle. The door is defined by its scale and handle direction.
+    The doors origin is at the pivot point of the door, not at the center.
+    """
+
+    name: PrefixedName
+    """
+    The name of the door.
+    """
+
+    handle_factory: HandleFactory
+    """
+    The factory used to create the handle of the door.
+    """
+
+    handle_direction: Direction
+    """
+    The direction on the door in which the handle positioned.
+    """
+
+    scale: Scale = field(default_factory=lambda: Scale(0.03, 1.0, 2.0))
+    """
+    The scale of the door.
+    """
+
+    def create(self) -> World:
+        """
+        Return a world with a door body at its root. The door has a handle and is defined by its scale and handle direction.
+        """
+
+        door_event = self.create_door_event().as_composite_set()
+
+        bounding_box_collection = BoundingBoxCollection.from_event(door_event)
+        body = Body(name=self.name)
+        collision = bounding_box_collection.as_shapes(reference_frame=body)
+        body.collision = collision
+        body.visual = collision
+
+        world = World()
+        world.add_body(body)
+
+        handle_world = self.handle_factory.create()
+        handle_view: Handle = handle_world.get_views_by_type(Handle)[0]
+        door_T_handle = self.create_door_T_handle()
+        connection_door_T_handle = FixedConnection(
+            world.root, handle_world.root, door_T_handle
+        )
+
+        world.merge_world(handle_world, connection_door_T_handle)
+        world.add_view(Door(name=self.name, handle=handle_view, body=body))
+
+        return world
+
+    def create_door_event(self) -> SimpleEvent:
+        """
+        Return an event representing a door with a specified scale and handle direction. The origin of the door is not
+        at the center of the door, but at the pivot point of the door.
+        """
+
+        x_interval = closed(-self.scale.x / 2, self.scale.x / 2)
+        y_interval = closed(-self.scale.y / 2, self.scale.y / 2)
+        z_interval = closed(-self.scale.z / 2, self.scale.z / 2)
+
+        match self.handle_direction:
+            case Direction.X:
+                x_interval = closed(0, self.scale.x)
+            case Direction.Y:
+                y_interval = closed(0, self.scale.y)
+            case Direction.Z:
+                raise NotImplementedError(
+                    f"Door Creation for handle_direction Z is not implemented yet"
+                )
+            case Direction.NEGATIVE_X:
+                x_interval = closed(-self.scale.x, 0)
+            case Direction.NEGATIVE_Y:
+                y_interval = closed(-self.scale.y, 0)
+            case Direction.NEGATIVE_Z:
+                raise NotImplementedError(
+                    f"Door Creation for handle_direction NEGATIVE_Z is not implemented yet"
+                )
+
+        door_event = SimpleEvent(
+            {
+                SpatialVariables.x.value: x_interval,
+                SpatialVariables.y.value: y_interval,
+                SpatialVariables.z.value: z_interval,
+            }
+        )
+
+        return door_event
+
+    def create_door_T_handle(self) -> Optional[TransformationMatrix]:
+        """
+        Return a transformation matrix that defines the position and orientation of the handle relative to the door.
+        :raises: NotImplementedError if the handle direction is Z or NEGATIVE_Z.
+        """
+        match self.handle_direction:
+            case Direction.X:
+                return TransformationMatrix.from_xyz_rpy(
+                    self.scale.x - 0.1, 0.05, 0, 0, 0, np.pi / 2
+                )
+            case Direction.Y:
+                return TransformationMatrix.from_xyz_rpy(
+                    0.05, (self.scale.y - 0.1), 0, 0, 0, 0
+                )
+            case Direction.Z:
+                raise NotImplementedError(
+                    f"Handle Creation for handle_direction Z is not implemented yet"
+                )
+            case Direction.NEGATIVE_X:
+                return TransformationMatrix.from_xyz_rpy(
+                    -(self.scale.x - 0.1), 0.05, 0, 0, 0, np.pi / 2
+                )
+            case Direction.NEGATIVE_Y:
+                return TransformationMatrix.from_xyz_rpy(
+                    0.05, -(self.scale.y - 0.1), 0, 0, 0, 0
+                )
+            case Direction.NEGATIVE_Z:
+                raise NotImplementedError(
+                    f"Handle Creation for handle_direction NEGATIVE_Z is not implemented yet"
+                )
+
+
+@dataclass
+class DoubleDoorFactory(ViewFactory[DoubleDoor]):
+    """
+    Factory for creating a double door with two doors and their handles.
+    """
+
+    name: PrefixedName
+    """
+    The name of the double door.
+    """
+
+    handle_factory: HandleFactory
+    """
+    The factory used to create the handles of the doors.
+    """
+
+    scale: Scale = field(default_factory=lambda: Scale(0.03, 1.0, 2.0))
+    """
+    The scale of the double door.
+    """
+
+    one_door_scale: Scale = field(init=False)
+    """
+    The scale of a single door, which is half the width of the double door.
+    """
+
+    def __post_init__(self):
+        """
+        Precompute the scale for a single door based on the double door scale.
+        """
+        self.one_door_scale = Scale(self.scale.x, self.scale.y / 2, self.scale.z)
+
+    def create(self) -> World:
+        """
+        Return a world with a virtual body at its root that is the parent of the two doors making up the double door.
+        """
+        door_factories = self.create_door_factories()
+
+        world = World()
+        double_door_body = Body(name=self.name)
+        world.add_body(double_door_body)
+
+        self.add_doors_to_world(parent_world=world, door_factories=door_factories)
+
+        double_door_view = DoubleDoor(
+            body=double_door_body, doors=world.get_views_by_type(Door)
+        )
+        world.add_view(double_door_view)
+
+        return world
+
+    def create_door_factories(self) -> List[DoorFactory]:
+        """
+        Returns two door factories for the double door, one for handle direction Y, and one for handle direction NEGATIVE_Y.
+        Creates one handle for each door.
+        """
+        handle_directions = [Direction.Y, Direction.NEGATIVE_Y]
+        door_factories = []
+
+        for index, direction in enumerate(handle_directions):
+            handle_name = PrefixedName(
+                self.name.name + f"_{index}_handle", self.name.prefix
+            )
+            handle_factory = HandleFactory(
+                handle_name,
+                self.handle_factory.scale,
+                self.handle_factory.thickness,
+            )
+
+            door_name = PrefixedName(self.name.name + f"_{index}", self.name.prefix)
+            door_factory = DoorFactory(
+                name=door_name,
+                scale=self.one_door_scale,
+                handle_factory=handle_factory,
+                handle_direction=direction,
+            )
+            door_factories.append(door_factory)
+
+        return door_factories
+
+    def add_doors_to_world(
+        self, parent_world: World, door_factories: List[DoorFactory]
+    ):
+        """
+        Adds doors to the parent world.
+        """
+        for door_factory in door_factories:
+            y_direction: float = self.one_door_scale.y / 2
+            if door_factory.handle_direction == Direction.Y:
+                y_direction = -y_direction
+
+            parent_T_door = TransformationMatrix.from_point_rotation_matrix(
+                Point3(
+                    self.one_door_scale.x / 2, y_direction, self.one_door_scale.z / 2
+                )
+            )
+
+            add_door_to_world(
+                door_factory=door_factory,
+                parent_T_door=parent_T_door,
+                parent_world=parent_world,
+            )
+
+
+@dataclass
+class DrawerFactory(ViewFactory[Drawer]):
+    """
+    Factory for creating a drawer with a handle and a container.
+    """
+
+    name: PrefixedName
+    """
+    The name of the drawer.
+    """
+
+    handle_factory: HandleFactory
+    """
+    The factory used to create the handle of the drawer.
+    """
+
+    container_factory: ContainerFactory
+    """
+    The factory used to create the container of the drawer.
+    """
+
+    def create(self) -> World:
+        """
+        Return a world with a drawer at its root. The drawer consists of a container and a handle.
+        """
+        container_world = self.container_factory.create()
+        container_view: Container = container_world.get_views_by_type(Container)[0]
+
+        handle_world = self.handle_factory.create()
+        handle_view: Handle = handle_world.get_views_by_type(Handle)[0]
+
+        drawer_T_handle = TransformationMatrix.from_xyz_rpy(
+            (self.container_factory.scale.x / 2) + 0.03, 0, 0, 0, 0, 0
+        )
+        connection_drawer_T_handle = FixedConnection(
+            parent=container_world.root,
+            child=handle_world.root,
+            origin_expression=drawer_T_handle,
+        )
+
+        container_world.merge_world(handle_world, connection_drawer_T_handle)
+        drawer_view = Drawer(
+            name=self.name, container=container_view, handle=handle_view
+        )
+        container_world.add_view(drawer_view)
+
+        return container_world
+
+
+@dataclass
+class DresserFactory(ViewFactory[Dresser]):
+    """
+    Factory for creating a dresser with drawers, and doors.
+    """
+
+    name: PrefixedName
+    """
+    The name of the dresser.
+    """
+
+    container_factory: ContainerFactory
+    """
+    The factory used to create the container of the dresser.
+    """
+
+    drawers_factories: List[DrawerFactory] = field(default_factory=list, hash=False)
+    """
+    The factories used to create the drawers of the dresser.
+    """
+
+    drawer_transforms: List[TransformationMatrix] = field(
+        default_factory=list, hash=False
+    )
+    """
+    The transformations for the drawers relative to the dresser container.
+    """
+
+    door_factories: List[DoorFactory] = field(default_factory=list, hash=False)
+    """
+    The factories used to create the doors of the dresser.
+    """
+
+    door_transforms: List[TransformationMatrix] = field(
+        default_factory=list, hash=False
+    )
+    """
+    The transformations for the doors relative to the dresser container.
+    """
+
+    def create(self) -> World:
+        """
+        Return a world with a dresser at its root. The dresser consists of a container, potentially drawers, and doors.
+        Assumes that the number of drawers matches the number of drawer transforms.
+        """
+        assert len(self.drawers_factories) == len(
+            self.drawer_transforms
+        ), "Number of drawers must match number of transforms"
+
+        dresser_world = self.make_dresser_world()
+
+        return self.make_interior(dresser_world)
+
+    def make_dresser_world(self) -> World:
+        """
+        Create a world with a dresser view that contains a container, drawers, and doors, but no interior yet.
+        """
+        dresser_world = self.container_factory.create()
+        container_view: Container = dresser_world.get_views_by_type(Container)[0]
+
+        for door_factory, parent_T_door in zip(
+            self.door_factories, self.door_transforms
+        ):
+            add_door_to_world(door_factory, parent_T_door, dresser_world)
+
+        self.add_drawers_to_world(dresser_world)
+
+        dresser_view = Dresser(
+            name=self.name,
+            container=container_view,
+            drawers=[drawer for drawer in dresser_world.get_views_by_type(Drawer)],
+            doors=[door for door in dresser_world.get_views_by_type(Door)],
+        )
+        dresser_world.add_view(dresser_view)
+
+        return dresser_world
+
+    def add_drawers_to_world(self, parent_world: World):
+        """
+        Adds drawers to the parent world. A prismatic connection is created for each drawer.
+        """
+        for drawer_factory, transform in zip(
+            self.drawers_factories, self.drawer_transforms
+        ):
+            drawer_world = drawer_factory.create()
+
+            drawer_view: Drawer = drawer_world.get_views_by_type(Drawer)[0]
+            drawer_body = drawer_view.container.body
+
+            lower_limits, upper_limits = self.create_drawer_upper_lower_limits(
+                drawer_factory=drawer_factory
+            )
+
+            dof = DegreeOfFreedom(
+                name=PrefixedName(
+                    f"{drawer_body.name.name}_connection", drawer_body.name.prefix
+                ),
+                lower_limits=lower_limits,
+                upper_limits=upper_limits,
+            )
+
+            connection = PrismaticConnection(
+                parent=parent_world.root,
+                child=drawer_body,
+                origin_expression=transform,
+                multiplier=1.0,
+                offset=0.0,
+                axis=Vector3.X(),
+                dof=dof,
+            )
+            parent_world.merge_world(drawer_world, connection)
+
+    def create_drawer_upper_lower_limits(
+        self, drawer_factory: DrawerFactory
+    ) -> Tuple[DerivativeMap[float], DerivativeMap[float]]:
+        """
+        Return the upper and lower limits for the drawer's degree of freedom.
+        """
+        lower_limits = DerivativeMap[float]()
+        lower_limits.position = 0.0
+        upper_limits = DerivativeMap[float]()
+        upper_limits.position = drawer_factory.container_factory.scale.x * 0.75
+
+        return lower_limits, upper_limits
+
+    def make_interior(self, world: World) -> World:
+        """
+        Create the interior of the dresser by subtracting the drawers and doors from the container, and filling  with
+        the remaining space.
+
+        :param world: The world containing the dresser body as its root.
+        """
+        dresser_body = world.root
+        container_event = dresser_body.as_bounding_box_collection(dresser_body).event
+
+        container_footprint = self.subtract_bodies_from_container_footprint(
+            world, container_event
+        )
+
+        container_event = self.fill_container_body(container_footprint, container_event)
+
+        collision_shapes = BoundingBoxCollection.from_event(container_event).as_shapes(
+            dresser_body
+        )
+        dresser_body.collision = collision_shapes
+        dresser_body.visual = collision_shapes
+        return world
+
+    def subtract_bodies_from_container_footprint(
+        self, world: World, container_event: Event
+    ) -> Event:
+        """
+        Subtract the bounding boxes of all bodies in the world from the container event,
+        except for the dresser body itself. This creates a frontal footprint of the container
+
+        :param world: The world containing the dresser body as its root.
+        :param container_event: The event representing the container.
+
+        :return: An event representing the footprint of the container after subtracting other bodies.
+        """
+        dresser_body = world.root
+
+        container_footprint = container_event.marginal(SpatialVariables.yz)
+
+        for body in world.bodies:
+            if body == dresser_body:
+                continue
+            body_footprint = body.as_bounding_box_collection(
+                dresser_body
+            ).event.marginal(SpatialVariables.yz)
+            container_footprint -= body_footprint
+
+        return container_footprint
+
+    def fill_container_body(
+        self, container_footprint: Event, container_event: Event
+    ) -> Event:
+        """
+        Expand container footprint into 3d space and fill the space of the resulting container body.
+
+        :param container_footprint: The footprint of the container in the yz-plane.
+        :param container_event: The event representing the container.
+
+        :return: An event representing the container body with the footprint filled in the x-direction.
+        """
+
+        container_footprint.fill_missing_variables([SpatialVariables.x.value])
+
+        depth_interval = container_event.bounding_box()[SpatialVariables.x.value]
+        limiting_event = SimpleEvent(
+            {SpatialVariables.x.value: depth_interval}
+        ).as_composite_set()
+        limiting_event.fill_missing_variables(SpatialVariables.yz)
+
+        container_event |= container_footprint & limiting_event
+
+        return container_event
+
+
+@dataclass
+class WallFactory(ViewFactory[Wall]):
+    name: PrefixedName
+    scale: Scale
+    door_factories: List[Union[DoorFactory, DoubleDoorFactory]] = field(
+        default_factory=list
+    )
+    door_transforms: List[TransformationMatrix] = field(default_factory=list)
+
+    def create(self) -> World:
+        """
+        Return a world with the wall body at its root and potentially doors and double doors as children of the wall body.
+        """
+
+        wall_collision = self._create_wall_collision()
+
+        wall_world = World()
+        wall_body = Body(
+            name=self.name, collision=wall_collision, visual=wall_collision
+        )
+        wall_world.add_body(wall_body)
+
+        self.add_doors_and_double_doors_to_world(wall_world)
+
+        wall = Wall(
+            name=self.name,
+            body=wall_body,
+        )
+
+        wall_world.add_view(wall)
+
+        return wall_world
+
+    def _create_wall_collision(self) -> List[Box]:
+        """
+        Return the collision shapes for the wall. A wall event is created based on the scale of the wall, and
+        doors are removed from the wall event. The resulting bounding box collection is converted to shapes.
+        """
+
+        wall_event = self.create_wall_event().as_composite_set()
+
+        wall_event = self.remove_doors_from_wall_event(wall_event)
+
+        bounding_box_collection = BoundingBoxCollection.from_event(wall_event)
+
+        wall_collision = bounding_box_collection.as_shapes()
+        return wall_collision
+
+    def create_wall_event(self) -> SimpleEvent:
+        """
+        Return a wall event created from its scale. The height origin is on the ground, not in the center of the wall.
+        """
+        x_interval = closed(-self.scale.x / 2, self.scale.x / 2)
+        y_interval = closed(-self.scale.y / 2, self.scale.y / 2)
+        z_interval = closed(0, self.scale.z)
+
+        wall_event = SimpleEvent(
+            {
+                SpatialVariables.x.value: x_interval,
+                SpatialVariables.y.value: y_interval,
+                SpatialVariables.z.value: z_interval,
+            }
+        )
+        return wall_event
+
+    def remove_doors_from_wall_event(self, wall_event: Event) -> Event:
+        """
+        Remove doors from the wall event by subtracting the door events from the wall event.
+        The doors are created from the door factories and their transforms.
+        """
+        for door_factory, door_transform in zip(
+            self.door_factories, self.door_transforms
+        ):
+            door_world = door_factory.create()
+            doors: List[Door] = door_world.get_views_by_type(Door)
+            door_transform = self.get_door_transforms(
+                doors, door_factory, door_transform
+            )
+
+            temp_world = self.build_temp_world(
+                door_world=door_world, door_transform=door_transform
+            )
+
+            if isinstance(door_factory, DoorFactory):
+                assert door_factory.handle_direction in {
+                    Direction.Y,
+                    Direction.NEGATIVE_Y,
+                }, "Currently only handles are only supported in Y direction"
+
+            door_plane_spatial_variables = SpatialVariables.yz
+            door_thickness_spatial_variable = SpatialVariables.x.value
+
+            for door in doors:
+                door_event = door.body.as_bounding_box_collection(temp_world.root).event
+                door_event = door_event.marginal(door_plane_spatial_variables)
+                door_event.fill_missing_variables([door_thickness_spatial_variable])
+
+                wall_event -= door_event
+
+        return wall_event
+
+    def get_door_transforms(
+        self, doors, door_factory, door_transform
+    ) -> TransformationMatrix:
+        """
+        Calculate the door pivot point based on the door factory and the door transform.
+        """
+        match door_factory:
+            case DoorFactory():
+                door_transform = calculate_door_pivot_point(
+                    doors[0], door_transform, door_factory.scale
+                )
+            case DoubleDoorFactory():
+                translation = door_transform.to_position().to_np()
+                door_transform = TransformationMatrix.from_point_rotation_matrix(
+                    Point3(translation[0], translation[1], 0)
+                )
+
+        return door_transform
+
+    def build_temp_world(
+        self, door_world: World, door_transform: TransformationMatrix
+    ) -> World:
+        """
+        Create a temporary world to merge the door world into the wall world. This temporary world is used to then cut
+        out the doors from the wall event.
+        """
+        temp_world = World()
+        temp_world.add_body(Body())
+
+        connection = FixedConnection(
+            parent=temp_world.root,
+            child=door_world.root,
+            origin_expression=door_transform,
+        )
+
+        temp_world.merge_world(door_world, connection)
+
+        return temp_world
+
+    def add_doors_and_double_doors_to_world(self, wall_world: World):
+        """
+        Adds doors and double doors to the wall world.
+        """
+        for door_factory, transform in zip(self.door_factories, self.door_transforms):
+            match door_factory:
+                case DoorFactory():
+                    add_door_to_world(door_factory, transform, wall_world)
+                case DoubleDoorFactory():
+                    door_world = door_factory.create()
+                    translation = transform.to_position().to_np()
+                    transform = TransformationMatrix.from_point_rotation_matrix(
+                        Point3(translation[0], translation[1], 0)
+                    )
+                    connection = FixedConnection(
+                        parent=wall_world.root,
+                        child=door_world.root,
+                        origin_expression=transform,
+                    )
+
+                    wall_world.merge_world(door_world, connection)
+
+
+def add_door_to_world(
+    door_factory: DoorFactory, parent_T_door: TransformationMatrix, parent_world: World
+):
+    door_world = door_factory.create()
+
+    door_view: Door = door_world.get_views_by_type(Door)[0]
+    door_body = door_view.body
+
+    lower_limits = DerivativeMap[float]()
+    upper_limits = DerivativeMap[float]()
+
+    lower_limits.position = -np.pi / 2
+    upper_limits.position = 0.0
+
+    if door_factory.handle_direction in {
+        Direction.NEGATIVE_X,
+        Direction.NEGATIVE_Y,
+    }:
+        lower_limits.position = 0.0
+        upper_limits.position = np.pi / 2
+
+    dof = parent_world.create_degree_of_freedom(
+        PrefixedName(f"{door_body.name.name}_connection", door_body.name.prefix),
+        lower_limits,
+        upper_limits,
+    )
+
+    pivot_point = calculate_door_pivot_point(
+        door_view, parent_T_door, door_factory.scale
+    )
+
+    connection = RevoluteConnection(
+        parent=parent_world.root,
+        child=door_body,
+        origin_expression=pivot_point,
+        multiplier=1.0,
+        offset=0.0,
+        axis=Vector3.Z(),
+        dof=dof,
+    )
+
+    parent_world.merge_world(door_world, connection)
+
+
+def calculate_door_pivot_point(
+    door_view, door_transform: TransformationMatrix, scale: Scale
+) -> TransformationMatrix:
+    parent_connection = door_view.handle.body.parent_connection
+    if parent_connection is None:
+        raise ValueError(
+            "Handle's body does not have a parent_connection; cannot compute handle_position."
+        )
+    handle_position: ndarray[float] = (
+        parent_connection.origin_expression.to_position().to_np()
+    )
+
+    offset = -np.sign(handle_position[1]) * (scale.y / 2)
+    door_position = door_transform.to_np()[:3, 3] + np.array([0, offset, 0])
+
+    door_transform = TransformationMatrix.from_point_rotation_matrix(
+        Point3(*door_position)
+    )
+
+    return door_transform
+
+
+def replace_dresser_drawer_connections(world: World):
+    dresser_pattern = re.compile(r"^dresser_\d+.*$")
+    drawer_pattern = re.compile(r"^.*_drawer_.*$")
+    door_pattern = re.compile(r"^.*_door_.*$")
+
+    dresser_bodies = [
+        b for b in world.bodies if bool(dresser_pattern.fullmatch(b.name.name))
+    ]
+    for dresser in dresser_bodies:
+        drawer_factories = []
+        drawer_transforms = []
+        door_factories = []
+        door_transforms = []
+        for child in dresser.child_bodies:
+            if bool(drawer_pattern.fullmatch(child.name.name)):
+                drawer_transforms.append(child.parent_connection.origin_expression)
+
+                handle_factory = HandleFactory(
+                    name=PrefixedName(child.name.name + "_handle", child.name.prefix)
+                )
+                container_factory = ContainerFactory(
+                    name=PrefixedName(
+                        child.name.name + "_container", child.name.prefix
+                    ),
+                    scale=child.as_bounding_box_collection(child._world.root)
+                    .bounding_boxes[0]
+                    .scale,
+                    direction=Direction.Z,
+                )
+                drawer_factory = DrawerFactory(
+                    name=child.name,
+                    handle_factory=handle_factory,
+                    container_factory=container_factory,
+                )
+                drawer_factories.append(drawer_factory)
+            elif bool(door_pattern.fullmatch(child.name.name)):
+                door_transforms.append(child.parent_connection.origin_expression)
+                handle_factory = HandleFactory(
+                    PrefixedName(child.name.name + "_handle", child.name.prefix)
+                )
+
+                door_factory = DoorFactory(
+                    name=child.name,
+                    scale=child.as_bounding_box_collection(child._world.root)
+                    .bounding_boxes[0]
+                    .scale,
+                    handle_factory=handle_factory,
+                    handle_direction=Direction.Y,
+                )
+                door_factories.append(door_factory)
+
+        dresser_container_factory = ContainerFactory(
+            name=PrefixedName(dresser.name.name + "_container", dresser.name.prefix),
+            scale=dresser.as_bounding_box_collection(dresser._world.root)
+            .bounding_boxes[0]
+            .scale,
+            direction=Direction.X,
+        )
+        dresser_factory = DresserFactory(
+            name=dresser.name,
+            container_factory=dresser_container_factory,
+            drawers_factories=drawer_factories,
+            drawer_transforms=drawer_transforms,
+            door_factories=door_factories,
+            door_transforms=door_transforms,
+        )
+
+        return dresser_factory

--- a/src/semantic_world/views/factories.py
+++ b/src/semantic_world/views/factories.py
@@ -28,7 +28,7 @@ from semantic_world.views import (
     Drawer,
     Door,
     Wall,
-    DoubleDoor,
+    DoubleDoor, EntryWay,
 )
 from semantic_world.world import World
 from semantic_world.world_entity import Body
@@ -274,9 +274,15 @@ class HandleFactory(ViewFactory[Handle]):
 
         return inner_box
 
+@dataclass
+class EntryWayFactory(ViewFactory[EntryWay], ABC):
+    """
+    Abstract factory for creating an entryway with a body.
+    """
+    ...
 
 @dataclass
-class DoorFactory(ViewFactory[Door]):
+class DoorFactory(ViewFactory[Door], EntryWayFactory):
     """
     Factory for creating a door with a handle. The door is defined by its scale and handle direction.
     The doors origin is at the pivot point of the door, not at the center.
@@ -401,7 +407,7 @@ class DoorFactory(ViewFactory[Door]):
 
 
 @dataclass
-class DoubleDoorFactory(ViewFactory[DoubleDoor]):
+class DoubleDoorFactory(ViewFactory[DoubleDoor], EntryWayFactory):
     """
     Factory for creating a double door with two doors and their handles.
     """
@@ -756,7 +762,7 @@ class DresserFactory(ViewFactory[Dresser]):
 class WallFactory(ViewFactory[Wall]):
     name: PrefixedName
     scale: Scale
-    door_factories: List[Union[DoorFactory, DoubleDoorFactory]] = field(
+    door_factories: List[EntryWayFactory] = field(
         default_factory=list
     )
     door_transforms: List[TransformationMatrix] = field(default_factory=list)

--- a/src/semantic_world/views/factories.py
+++ b/src/semantic_world/views/factories.py
@@ -275,14 +275,14 @@ class HandleFactory(ViewFactory[Handle]):
         return inner_box
 
 @dataclass
-class EntryWayFactory(ViewFactory[EntryWay], ABC):
+class EntryWayFactory(ViewFactory[T], ABC):
     """
     Abstract factory for creating an entryway with a body.
     """
     ...
 
 @dataclass
-class DoorFactory(ViewFactory[Door], EntryWayFactory):
+class DoorFactory(EntryWayFactory[Door]):
     """
     Factory for creating a door with a handle. The door is defined by its scale and handle direction.
     The doors origin is at the pivot point of the door, not at the center.
@@ -407,7 +407,7 @@ class DoorFactory(ViewFactory[Door], EntryWayFactory):
 
 
 @dataclass
-class DoubleDoorFactory(ViewFactory[DoubleDoor], EntryWayFactory):
+class DoubleDoorFactory(EntryWayFactory[DoubleDoor]):
     """
     Factory for creating a double door with two doors and their handles.
     """

--- a/src/semantic_world/views/views.py
+++ b/src/semantic_world/views/views.py
@@ -118,10 +118,17 @@ class Furniture(View): ...
 
 #################### subclasses von Components
 
+@dataclass(unsafe_hash=True)
+class EntryWay(Components):
+    body: Body
+
+    def __post_init__(self):
+        if self.name is None:
+            self.name = PrefixedName(str(self.body.name), self.__class__.__name__)
+
 
 @dataclass(unsafe_hash=True)
-class Door(Components):
-    body: Body
+class Door(EntryWay):
     handle: Handle
 
     def __post_init__(self):
@@ -130,8 +137,7 @@ class Door(Components):
 
 
 @dataclass(unsafe_hash=True)
-class DoubleDoor(Components):
-    body: Body
+class DoubleDoor(EntryWay):
     doors: List[Door] = field(default_factory=list, hash=False)
 
     def __post_init__(self):

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -394,10 +394,7 @@ class World:
     def deleted_orphaned_dof(self):
         actual_dofs = set()
         for connection in self.connections:
-            if isinstance(connection, ActiveConnection):
-                actual_dofs.update(set(connection.active_dofs))
-            if isinstance(connection, PassiveConnection):
-                actual_dofs.update(set(connection.passive_dofs))
+            actual_dofs.update(connection.dofs)
         self.degrees_of_freedom = list(actual_dofs)
 
 
@@ -577,6 +574,7 @@ class World:
             self.register_degree_of_freedom(dof)
         self.add_connection(connection)
 
+    @modifies_world
     def merge_world_at_pose(self, other: World, pose: cas.TransformationMatrix) -> None:
         """
         Merge another world into the existing one, creates a 6DoF connection between the root of this world and the root
@@ -587,7 +585,6 @@ class World:
         root_connection = Connection6DoF(parent=self.root, child=other.root, _world=self)
         root_connection.origin = pose
         self.merge_world(other, root_connection)
-        self.add_connection(root_connection)
 
     def __str__(self):
         return f"{self.__class__.__name__} with {len(self.bodies)} bodies."

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -563,7 +563,7 @@ class World:
                 other.remove_body(body)
 
         for view in other.views:
-            self.add_view(view)
+            self.add_view(view, exists_ok=True)
 
         other.world_is_being_modified = False
 

--- a/src/semantic_world/world_entity.py
+++ b/src/semantic_world/world_entity.py
@@ -7,28 +7,29 @@ from dataclasses import dataclass, field
 from dataclasses import fields
 from functools import lru_cache
 from functools import reduce
-from typing import Deque
+from typing import (
+    Deque,
+)
 from typing import List, Optional, TYPE_CHECKING, Tuple
 from typing import Set
 
 import numpy as np
-from numpy import ndarray
+import rustworkx
 from scipy.stats import geom
 from trimesh.proximity import closest_point, nearby_faces
 from trimesh.sample import sample_surface
 
-from .geometry import BoundingBox, BoundingBoxCollection
+from .geometry import BoundingBoxCollection
 from .geometry import Shape
 from .prefixed_name import PrefixedName
 from .spatial_types import spatial_types as cas
-from .spatial_types.spatial_types import Point3
 from .spatial_types.spatial_types import TransformationMatrix, Expression
 from .types import NpMatrix4x4
 from .utils import IDGenerator
 
 if TYPE_CHECKING:
-    from .world import World
     from .degree_of_freedom import DegreeOfFreedom
+    from .world import World
 
 id_generator = IDGenerator()
 
@@ -170,9 +171,17 @@ class Body(WorldEntity):
     @property
     def child_bodies(self) -> List[Body]:
         """
-        Returns the child bodies of this body.
+        Returns the direct child bodies of this body.
         """
         return self._world.compute_child_bodies(self)
+
+    @property
+    def recursive_child_bodies(self) -> List[Body]:
+        """
+        Returns the recursive child bodies of this body.
+        :return: All child bodies of this body.
+        """
+        return [self._world.kinematic_structure[i] for i in rustworkx.descendants(self._world.kinematic_structure, self.index)]
 
     @property
     def parent_body(self) -> Body:
@@ -181,42 +190,25 @@ class Body(WorldEntity):
         """
         return self._world.compute_parent_body(self)
 
-    @property
-    def bounding_box_collection(self) -> BoundingBoxCollection:
+    def as_bounding_box_collection(self, reference_frame: Optional[Body] = None) -> BoundingBoxCollection:
         """
-        Return the bounding box collection of the link with the given name.
-        This method computes the bounding box of the link in world coordinates by transforming the local axis-aligned
-        bounding boxes of the link's geometry to world coordinates.
+        Provides the bounding box collection for the current object based on its
+        relative transformations and collision shapes.
 
-        Note: These bounding boxes may not be disjoint, however the random events library always makes them disjoint. If
-        this is the case, and we feed he non-disjoint bounding boxes into the gcs, it may trigger unexpected behavior.
+        This property computes the forward kinematics to determine the object's
+        position and orientation in world space. Bounding boxes for each shape in the
+        collision attribute are transformed to world coordinates. The world-space bounding
+        boxes are then aggregated into a BoundingBoxCollection.
 
-        :return: A BoundingBoxCollection containing the bounding boxes of the link's geometry in world
+        :returns: A collection of bounding boxes in world-space coordinates.
+        :rtype: BoundingBoxCollection
         """
-        world = self._world
-        body_transform: ndarray = world.compute_forward_kinematics_np(world.root, self)
         world_bboxes = []
 
         for shape in self.collision:
-            shape_transform: ndarray = shape.origin.to_np()
-
-            world_transform: ndarray = body_transform @ shape_transform
-            body_pos = world_transform[:3, 3]
-            body_rotation_matrix = world_transform[:3, :3]
-
-            local_bb: BoundingBox = shape.as_bounding_box()
-
-            # Get all 8 corners of the BB in link-local space
-            corners = np.array([corner.to_np()[:3] for corner in local_bb.get_points()])  # shape (8, 3)
-
-            # Transform each corner to world space: R * corner + T
-            transformed_corners = (corners @ body_rotation_matrix.T) + body_pos
-
-            # Compute world-space bounding box from transformed corners
-            min_corner = np.min(transformed_corners, axis=0)
-            max_corner = np.max(transformed_corners, axis=0)
-
-            world_bb = BoundingBox.from_min_max(Point3(*min_corner), Point3(*max_corner))
+            if shape.origin.reference_frame is None:
+                continue
+            world_bb = shape.as_bounding_box(reference_frame)
             world_bboxes.append(world_bb)
 
         return BoundingBoxCollection(world_bboxes)
@@ -245,7 +237,6 @@ class Body(WorldEntity):
         new_link._world = body._world
         new_link.index = body.index
         return new_link
-
 
 @dataclass
 class View(WorldEntity):
@@ -293,13 +284,13 @@ class View(WorldEntity):
         """
         return self._bodies(set())
 
-    def as_bounding_box_collection(self) -> BoundingBoxCollection:
+    def as_bounding_box_collection(self, reference_frame: Optional[Body] = None) -> BoundingBoxCollection:
         """
         Returns a bounding box collection that contains the bounding boxes of all bodies in this view.
         """
         bbs = reduce(
             lambda accumulator, bb_collection: accumulator.merge(bb_collection),
-            (body.bounding_box_collection for body in self.bodies if body.has_collision())
+            (body.as_bounding_box_collection(reference_frame) for body in self.bodies if body.has_collision())
         )
         return bbs
 

--- a/test/test_factories/test_factories.py
+++ b/test/test_factories/test_factories.py
@@ -1,0 +1,160 @@
+import unittest
+
+from semantic_world.geometry import Scale
+from semantic_world.prefixed_name import PrefixedName
+from semantic_world.spatial_types.spatial_types import TransformationMatrix
+from semantic_world.views import Handle, Door, Container, Drawer, Dresser, Wall
+from semantic_world.views.factories import (
+    HandleFactory,
+    Direction,
+    DoorFactory,
+    ContainerFactory,
+    DoubleDoorFactory,
+    DrawerFactory,
+    DresserFactory,
+    WallFactory,
+)
+
+
+class TestFactories(unittest.TestCase):
+    def test_handle_factory(self):
+
+        factory = HandleFactory(name=PrefixedName("handle"))
+        world = factory.create()
+        handle_views = world.get_views_by_type(Handle)
+        self.assertEqual(len(handle_views), 1)
+
+        handle: Handle = handle_views[0]
+        self.assertEqual(world.root, handle.body)
+
+        # this belongs into whatever tests merge_world, and with dummy objects, not handles
+        for i in range(10):
+            factory = HandleFactory(name=PrefixedName(f"handle_{i}"))
+            world.merge_world(factory.create())
+
+        self.assertEqual(world.root.name.name, "handle")
+        handle_views = world.get_views_by_type(Handle)
+        self.assertEqual(11, len(handle_views))
+        self.assertEqual(11, len(world.bodies))
+
+    def test_door_factory(self):
+        factory = DoorFactory(
+            name=PrefixedName("door"),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+            handle_direction=Direction.Y,
+        )
+        world = factory.create()
+        door_views = world.get_views_by_type(Door)
+        self.assertEqual(len(door_views), 1)
+
+        door: Door = door_views[0]
+        self.assertEqual(world.root, door.body)
+        self.assertIsInstance(door.handle, Handle)
+
+    def test_double_door_factory(self):
+        factory = DoubleDoorFactory(
+            name=PrefixedName("double_door"),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+        )
+        world = factory.create()
+        door_views = world.get_views_by_type(Door)
+        self.assertEqual(len(door_views), 2)
+
+        doors: list[Door] = door_views
+        self.assertEqual(set(world.root.child_bodies), {doors[0].body, doors[1].body})
+        self.assertIsInstance(doors[0].handle, Handle)
+        self.assertIsInstance(doors[1].handle, Handle)
+        self.assertNotEqual(doors[0].handle, doors[1].handle)
+
+    def test_container_factory(self):
+        factory = ContainerFactory(name=PrefixedName("container"))
+        world = factory.create()
+        container_views = world.get_views_by_type(Container)
+        self.assertEqual(len(container_views), 1)
+
+        container: Container = container_views[0]
+        self.assertEqual(world.root, container.body)
+
+    def test_drawer_factory(self):
+
+        factory = DrawerFactory(
+            name=PrefixedName("drawer"),
+            container_factory=ContainerFactory(name=PrefixedName("container")),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+        )
+        world = factory.create()
+        drawer_views = world.get_views_by_type(Drawer)
+        self.assertEqual(len(drawer_views), 1)
+
+        drawer: Drawer = drawer_views[0]
+        self.assertEqual(world.root, drawer.container.body)
+
+    def test_dresser_factory(self):
+        drawer_factory = DrawerFactory(
+            name=PrefixedName("drawer"),
+            container_factory=ContainerFactory(name=PrefixedName("container")),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+        )
+        drawer_transform = TransformationMatrix()
+
+        door_factory = DoorFactory(
+            name=PrefixedName("door"),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+            handle_direction=Direction.Y,
+        )
+
+        door_transform = TransformationMatrix()
+
+        container_factory = ContainerFactory(name=PrefixedName("container"))
+
+        dresser_factory = DresserFactory(
+            name=PrefixedName("dresser"),
+            drawer_transforms=[drawer_transform],
+            drawers_factories=[drawer_factory],
+            door_transforms=[door_transform],
+            door_factories=[door_factory],
+            container_factory=container_factory,
+        )
+
+        world = dresser_factory.create()
+        dresser_views = world.get_views_by_type(Dresser)
+        drawers_views = world.get_views_by_type(Drawer)
+        door_views = world.get_views_by_type(Door)
+        self.assertEqual(len(drawers_views), 1)
+        self.assertEqual(len(dresser_views), 1)
+        self.assertEqual(len(door_views), 1)
+        dresser: Dresser = dresser_views[0]
+        self.assertEqual(world.root, dresser.container.body)
+
+    def test_wall_factory(self):
+
+        door_factory = DoorFactory(
+            name=PrefixedName("door"),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+            handle_direction=Direction.Y,
+        )
+
+        door_transform = TransformationMatrix()
+
+        double_door_factory = DoubleDoorFactory(
+            name=PrefixedName("double_door"),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+        )
+        double_door_transform = TransformationMatrix()
+
+        factory = WallFactory(
+            name=PrefixedName("wall"),
+            scale=Scale(0.1, 4, 2),
+            door_transforms=[door_transform, double_door_transform],
+            door_factories=[door_factory, double_door_factory],
+        )
+        world = factory.create()
+        wall_views = world.get_views_by_type(Wall)
+        self.assertEqual(len(wall_views), 1)
+
+        wall: Wall = wall_views[0]
+        self.assertEqual(world.root, wall.body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_spatial_variables/test_spatial_variables.py
+++ b/test/test_spatial_variables/test_spatial_variables.py
@@ -1,0 +1,52 @@
+import unittest
+
+from random_events.variable import Continuous
+from sortedcontainers import SortedSet
+
+from semantic_world.variables import SpatialVariables
+
+
+class TestSpatialVariables(unittest.TestCase):
+    def test_enum_members_exist(self):
+
+        self.assertTrue(hasattr(SpatialVariables, "x"))
+        self.assertTrue(hasattr(SpatialVariables, "y"))
+        self.assertTrue(hasattr(SpatialVariables, "z"))
+
+        self.assertEqual(SpatialVariables.x.value, Continuous('x'))
+        self.assertEqual(SpatialVariables.y.value, Continuous('y'))
+        self.assertEqual(SpatialVariables.z.value, Continuous('z'))
+
+        # Distinct members and distinct underlying values
+        self.assertNotEqual(SpatialVariables.x, SpatialVariables.y)
+        self.assertNotEqual(SpatialVariables.x, SpatialVariables.z)
+        self.assertNotEqual(SpatialVariables.y, SpatialVariables.z)
+
+        values = [SpatialVariables.x.value, SpatialVariables.y.value, SpatialVariables.z.value]
+        self.assertEqual(len(set(values)), 3, "Underlying values for x, y, z should be distinct")
+
+    def test_xy_contains_correct_members(self):
+        xy = SpatialVariables.xy
+        expected = {SpatialVariables.x.value, SpatialVariables.y.value}
+        self.assertEqual(set(xy), expected, "xy should contain exactly x and y values")
+        if SortedSet is not None:
+            self.assertIsInstance(xy, SortedSet)
+
+    def test_xz_contains_correct_members(self):
+        xz = SpatialVariables.xz
+        expected = {SpatialVariables.x.value, SpatialVariables.z.value}
+        self.assertEqual(set(xz), expected, "xz should contain exactly x and z values")
+        if SortedSet is not None:
+            self.assertIsInstance(xz, SortedSet)
+
+    def test_yz_contains_correct_members(self):
+        yz = SpatialVariables.yz
+        expected = {SpatialVariables.y.value, SpatialVariables.z.value}
+        self.assertEqual(set(yz), expected, "yz should contain exactly y and z values")
+        if SortedSet is not None:
+            self.assertIsInstance(yz, SortedSet)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_worlds/test_gcs.py
+++ b/test/test_worlds/test_gcs.py
@@ -67,16 +67,16 @@ class GCSFromWorldTestCase(unittest.TestCase):
         cls.world = apartment_parser.parse()
 
     def test_from_world(self):
-        search_space = BoundingBox(min_x=-5, max_x=-2,
-                                   min_y=-1, max_y=2,
+        search_space = BoundingBox(min_x=-2, max_x=2,
+                                   min_y=-2, max_y=2,
                                    min_z=0, max_z=2).as_collection()
         gcs = GraphOfConvexSets.free_space_from_world(self.world, search_space=search_space)
         self.assertIsNotNone(gcs)
         self.assertGreater(len(gcs.graph.nodes()), 0)
         self.assertGreater(len(gcs.graph.edges()), 0)
 
-        start = Point3(-4.5, -0.5, 0.4)
-        target = Point3(-2.5, 1.5, 0.9)
+        start = Point3(-1.5, -0.5, 0.4)
+        target = Point3(1.5, 1.5, 0.9)
 
         path = gcs.path_from_to(start, target)
 
@@ -89,8 +89,8 @@ class GCSFromWorldTestCase(unittest.TestCase):
             gcs.path_from_to(start, target)
 
     def test_navigation_map_from_world(self):
-        search_space = BoundingBox(min_x=-5, max_x=-2,
-                                   min_y=-1, max_y=2,
+        search_space = BoundingBox(min_x=-2, max_x=2,
+                                   min_y=-2, max_y=2,
                                    min_z=0, max_z=2).as_collection()
         gcs = GraphOfConvexSets.navigation_map_from_world(self.world, search_space=search_space)
         self.assertGreater(len(gcs.graph.nodes()), 0)

--- a/test/test_worlds/test_gcs.py
+++ b/test/test_worlds/test_gcs.py
@@ -67,16 +67,16 @@ class GCSFromWorldTestCase(unittest.TestCase):
         cls.world = apartment_parser.parse()
 
     def test_from_world(self):
-        search_space = BoundingBox(min_x=-2, max_x=2,
-                                   min_y=-2, max_y=2,
+        search_space = BoundingBox(min_x=-5, max_x=-2,
+                                   min_y=-1, max_y=2,
                                    min_z=0, max_z=2).as_collection()
         gcs = GraphOfConvexSets.free_space_from_world(self.world, search_space=search_space)
         self.assertIsNotNone(gcs)
         self.assertGreater(len(gcs.graph.nodes()), 0)
         self.assertGreater(len(gcs.graph.edges()), 0)
 
-        start = Point3(-1.5, -0.5, 0.4)
-        target = Point3(1.5, 1.5, 0.9)
+        start = Point3(-4.5, -0.5, 0.4)
+        target = Point3(-2.5, 1.5, 0.9)
 
         path = gcs.path_from_to(start, target)
 
@@ -89,8 +89,8 @@ class GCSFromWorldTestCase(unittest.TestCase):
             gcs.path_from_to(start, target)
 
     def test_navigation_map_from_world(self):
-        search_space = BoundingBox(min_x=-2, max_x=2,
-                                   min_y=-2, max_y=2,
+        search_space = BoundingBox(min_x=-5, max_x=-2,
+                                   min_y=-1, max_y=2,
                                    min_z=0, max_z=2).as_collection()
         gcs = GraphOfConvexSets.navigation_map_from_world(self.world, search_space=search_space)
         self.assertGreater(len(gcs.graph.nodes()), 0)


### PR DESCRIPTION
# Feature: ViewFactories

With this PR @tomsch420 and I introduce ViewFactories to the semantic digital twin. This enables us to create our own articulated furniture models. We can influence the specifics of the created body collisions using input parameters.

<img width="754" height="517" alt="image" src="https://github.com/user-attachments/assets/b8f47e6e-f04d-4735-bcc4-11e21299a38c" />

We can then fill the interior of the body using random events, so that we are left with a solid Dresser with 4 Drawers and 4 Doors.

The input parameters were chosen based on the information we are provided by procthor json files as well as fbx files, as this will be our first usecase for these factories in a future PR.

---

## Other Changes

- the as_bounding_box methods of shapes was generalized and pulled up into the shape super class. The variable names were adjusted to adhere to the style guide
- orphaned DoF are now removed from a world during model change. in that regard we also now have 'register_degree_of_freedom' method, since we may want to create DoF by hand at some points, and doing that using the 'create_degree_of_freedom' without being in another 'with world.modify_world()' context block adds a DoF to the world, notifies the model change, and then instantly deletes it again. So now we have a explicit method for registering the dof.
- Merge_world now correctly also transfers the views to the new world
- Adds xz and yz spatial variable combinations to SpatialVariables enum

---

Credit: Layout inspired by [SciPy](https://docs.scipy.org/doc/scipy/release/1.15.0-notes.html)
