### PR TITLE
[Restructuring] no import shortcuts.

### DIFF
--- a/doc/world_reasoner.md
+++ b/doc/world_reasoner.md
@@ -88,8 +88,8 @@ from posixpath import dirname
 from typing_extensions import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
 from ripple_down_rules.rdr import GeneralRDR
 from ripple_down_rules.datastructures.dataclasses import CaseQuery
-from semantic_world.world_description import View
-from semantic_world.reasoning import WorldReasoner
+from semantic_world.world_description.world_entity import View
+from semantic_world.reasoning.world_reasoner import WorldReasoner
 from semantic_world.world import World
 from semantic_world.views.views import Drawer
 
@@ -108,8 +108,8 @@ from posixpath import dirname
 from typing_extensions import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
 from ripple_down_rules.rdr import GeneralRDR
 from ripple_down_rules.datastructures.dataclasses import CaseQuery
-from semantic_world.world_description import View
-from semantic_world.reasoning import WorldReasoner
+from semantic_world.world_description.world_entity import View
+from semantic_world.reasoning.world_reasoner import WorldReasoner
 from semantic_world.world import World
 from semantic_world.views.views import Drawer
 

--- a/examples/graph_of_convex_sets.md
+++ b/examples/graph_of_convex_sets.md
@@ -35,8 +35,9 @@ You can read more about GCS [here](https://arxiv.org/abs/2101.11565).
 Let's get hands on! First, we need to create a world that makes navigation non-trivial.
 
 ```{code-cell} ipython2
-from semantic_world.world_description import Box, Scale, Color, Body
-from semantic_world.datastructures import PrefixedName
+from semantic_world.world_description.geometry import Box, Scale, Color
+from semantic_world.world_description.world_entity import Body
+from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.spatial_types import TransformationMatrix
 from semantic_world.world import World
 
@@ -56,7 +57,8 @@ be unable to fly by constraining the z-axis. Otherwise, he would get the idea to
 
 ```{code-cell} ipython2
 from random_events.interval import SimpleInterval
-from semantic_world.world_description import GraphOfConvexSets, BoundingBox
+from semantic_world.world_description.graph_of_convex_sets import GraphOfConvexSets
+from semantic_world.world_description.geometry import BoundingBox
 
 search_space = BoundingBox(min_x=-1, max_x=1,
                            min_y=-1, max_y=1,

--- a/scripts/generate_orm.py
+++ b/scripts/generate_orm.py
@@ -8,7 +8,7 @@ import semantic_world.world_description.degree_of_freedom
 import semantic_world.robots
 import semantic_world.views.views
 import semantic_world.world_description.world_entity
-from semantic_world.world_description import FixedConnection
+from semantic_world.world_description.connections import FixedConnection
 from semantic_world.orm.model import *
 from semantic_world.datastructures.prefixed_name import PrefixedName
 

--- a/src/semantic_world/adapters/mesh.py
+++ b/src/semantic_world/adapters/mesh.py
@@ -3,13 +3,13 @@ from dataclasses import dataclass
 
 import trimesh
 
-from ..world_description import Connection6DoF
+from ..world_description.connections import Connection6DoF
 from ..spatial_types.spatial_types import RotationMatrix
-from ..world_description import Mesh, TriangleMesh
-from ..datastructures import PrefixedName
+from ..world_description.geometry import Mesh, TriangleMesh
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types import TransformationMatrix, Point3
 from ..world import World
-from ..world_description import Body
+from ..world_description.world_entity import Body
 
 
 @dataclass

--- a/src/semantic_world/adapters/multi_parser.py
+++ b/src/semantic_world/adapters/multi_parser.py
@@ -27,9 +27,9 @@ except ImportError as e:
     JointType = None
     UsdUrdf = None
 
-from ..world_description import RevoluteConnection, PrismaticConnection, FixedConnection
-from ..world_description import DegreeOfFreedom
-from ..datastructures import PrefixedName
+from ..world_description.connections import RevoluteConnection, PrismaticConnection, FixedConnection
+from ..world_description.degree_of_freedom import DegreeOfFreedom
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types import spatial_types as cas
 from ..spatial_types.derivatives import DerivativeMap
 from ..world import World, Body, Connection

--- a/src/semantic_world/adapters/ros/world_synchronizer.py
+++ b/src/semantic_world/adapters/ros/world_synchronizer.py
@@ -16,9 +16,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ...orm.ormatic_interface import *
-from ...datastructures import PrefixedName
+from ...datastructures.prefixed_name import PrefixedName
 from ...world import World
-from ...world_description import (WorldModelModificationBlock, WorldModelModification, )
+from ...world_description.world_modification import (WorldModelModificationBlock, WorldModelModification, )
 
 
 @dataclass

--- a/src/semantic_world/adapters/urdf.py
+++ b/src/semantic_world/adapters/urdf.py
@@ -6,7 +6,8 @@ from typing_extensions import Optional, Tuple, Union, List, Dict
 
 from urdf_parser_py import urdf as urdfpy
 
-from ..world_description import (RevoluteConnection, PrismaticConnection, FixedConnection, DegreeOfFreedom)
+from ..world_description.connections import (RevoluteConnection, PrismaticConnection, FixedConnection)
+from ..world_description.degree_of_freedom import DegreeOfFreedom
 from ..exceptions import ParsingError
 from ..world_description.geometry import Box, Sphere, Cylinder, Mesh, Scale, Shape, Color
 from ..datastructures.prefixed_name import PrefixedName

--- a/src/semantic_world/adapters/viz_marker.py
+++ b/src/semantic_world/adapters/viz_marker.py
@@ -19,7 +19,7 @@ except ImportError as e:
 
 from scipy.spatial.transform import Rotation
 
-from ..world_description import Mesh, Box, Sphere, Cylinder, Primitive, TriangleMesh
+from ..world_description.geometry import Mesh, Box, Sphere, Cylinder, Primitive, TriangleMesh
 from ..world import World
 
 

--- a/src/semantic_world/calculations/ik_solver.py
+++ b/src/semantic_world/calculations/ik_solver.py
@@ -8,13 +8,13 @@ from typing_extensions import Dict, TYPE_CHECKING, List, Tuple
 import daqp
 import numpy as np
 
-from ..world_description import ActiveConnection, PassiveConnection
+from ..world_description.connections import ActiveConnection, PassiveConnection
 from ..world_description.degree_of_freedom import DegreeOfFreedom
 from ..spatial_types import spatial_types as cas
 
 if TYPE_CHECKING:
     from ..world import World
-    from ..world_description import Body
+    from ..world_description.world_entity import Body
 
 
 _large_value = np.inf

--- a/src/semantic_world/calculations/raytracer.py
+++ b/src/semantic_world/calculations/raytracer.py
@@ -6,8 +6,8 @@ import numpy as np
 import trimesh
 from trimesh import Scene
 
-from ..datastructures import NpMatrix4x4
-from ..world_description import Body
+from ..datastructures.types import NpMatrix4x4
+from ..world_description.world_entity import Body
 
 if TYPE_CHECKING:
     from ..world import World

--- a/src/semantic_world/collision_checking/collision_detector.py
+++ b/src/semantic_world/collision_checking/collision_detector.py
@@ -7,7 +7,8 @@ from typing_extensions import Tuple, Set, List, Optional
 
 import numpy as np
 
-from ..world_description import ActiveConnection, Body
+from ..world_description.connections import ActiveConnection
+from ..world_description.world_entity import Body
 from ..world import World
 
 

--- a/src/semantic_world/datastructures/__init__.py
+++ b/src/semantic_world/datastructures/__init__.py
@@ -1,3 +1,0 @@
-from .prefixed_name import PrefixedName
-from .types import AnyMatrix4x4, NpMatrix4x4
-from .variables import SpatialVariables

--- a/src/semantic_world/exceptions.py
+++ b/src/semantic_world/exceptions.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing_extensions import Optional, List, Type, TYPE_CHECKING
 
-from .datastructures import PrefixedName
+from .datastructures.prefixed_name import PrefixedName
 
 if TYPE_CHECKING:
     from .world import World
-    from .world_description import View, WorldEntity
+    from .world_description.world_entity import View, WorldEntity
 
 
 class LogicalError(Exception):

--- a/src/semantic_world/orm/model.py
+++ b/src/semantic_world/orm/model.py
@@ -8,14 +8,15 @@ import trimesh.exchange.stl
 from ormatic.dao import AlternativeMapping
 from sqlalchemy import TypeDecorator, types
 
-from ..world_description import DegreeOfFreedom
-from ..datastructures import PrefixedName
+from ..world_description.degree_of_freedom import DegreeOfFreedom
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types import RotationMatrix, Vector3, Point3, TransformationMatrix
 from ..spatial_types.derivatives import DerivativeMap
 from ..spatial_types.spatial_types import Quaternion
 from ..spatial_types.symbol_manager import symbol_manager
 from ..world import World, Body
-from ..world_description import Connection, View
+from ..world_description.connections import Connection
+from ..world_description.world_entity import View
 
 
 @dataclass

--- a/src/semantic_world/reasoning/__init__.py
+++ b/src/semantic_world/reasoning/__init__.py
@@ -1,2 +1,0 @@
-from .world_reasoner import WorldReasoner
-from .reasoner import CaseReasoner

--- a/src/semantic_world/reasoning/world_rdr/world_views_mcrdr_defs.py
+++ b/src/semantic_world/reasoning/world_rdr/world_views_mcrdr_defs.py
@@ -1,7 +1,7 @@
 from typing_extensions import List, Union
 
 from ...views.views import Cabinet, Container, Door, Drawer, Fridge, Handle
-from ...world_description import FixedConnection, PrismaticConnection, RevoluteConnection
+from ...world_description.connections import FixedConnection, PrismaticConnection, RevoluteConnection
 from ...world import World
 
 

--- a/src/semantic_world/reasoning/world_reasoner.py
+++ b/src/semantic_world/reasoning/world_reasoner.py
@@ -4,7 +4,7 @@ from os.path import dirname
 from typing_extensions import Optional, List, Dict, Any, Type, Callable, ClassVar
 
 from semantic_world.world import World
-from semantic_world.world_description import View
+from semantic_world.world_description.world_entity import View
 from semantic_world.reasoning.reasoner import CaseReasoner
 
 

--- a/src/semantic_world/spatial_types/math.py
+++ b/src/semantic_world/spatial_types/math.py
@@ -3,7 +3,7 @@ from typing_extensions import Tuple, Union, List
 import numpy as np
 
 from .derivatives import Derivatives
-from ..datastructures import NpMatrix4x4, AnyMatrix4x4
+from ..datastructures.types import NpMatrix4x4, AnyMatrix4x4
 
 
 def quaternion_multiply(quaternion1: np.ndarray, quaternion0: np.ndarray) -> np.ndarray:

--- a/src/semantic_world/spatial_types/spatial_types.py
+++ b/src/semantic_world/spatial_types/spatial_types.py
@@ -13,7 +13,7 @@ import casadi as ca
 import numpy as np
 
 if TYPE_CHECKING:
-    from ..world_description import KinematicStructureEntity
+    from ..world_description.world_entity import KinematicStructureEntity
 
 builtin_max = builtins.max
 builtin_min = builtins.min

--- a/src/semantic_world/spatial_types/spatial_types.pyi
+++ b/src/semantic_world/spatial_types/spatial_types.pyi
@@ -10,7 +10,7 @@ import casadi as ca
 from scipy import sparse as sp
 
 if TYPE_CHECKING:
-    from ..world_description import KinematicStructureEntity
+    from ..world_description.world_entity import KinematicStructureEntity
 
 all_expressions = Union[
     Symbol_,

--- a/src/semantic_world/spatial_types/symbol_manager.py
+++ b/src/semantic_world/spatial_types/symbol_manager.py
@@ -3,7 +3,7 @@ from typing_extensions import Dict, Callable, Union, Tuple, List
 import numpy as np
 
 from . import spatial_types as cas
-from ..datastructures import AnyMatrix4x4
+from ..datastructures.types import AnyMatrix4x4
 
 Provider = Union[float, Callable[[], float]]
 

--- a/src/semantic_world/views/factories.py
+++ b/src/semantic_world/views/factories.py
@@ -10,8 +10,11 @@ from ..world_description.connections import (
     FixedConnection,
     RevoluteConnection,
 )
-from ..world_description import DegreeOfFreedom, Scale, BoundingBoxCollection, Box, Body
-from ..datastructures import PrefixedName, SpatialVariables
+from ..world_description.degree_of_freedom import DegreeOfFreedom
+from ..world_description.geometry import Scale, BoundingBoxCollection, Box
+from ..world_description.world_entity import Body
+from ..datastructures.prefixed_name import PrefixedName
+from ..datastructures.variables import SpatialVariables
 from ..spatial_types.derivatives import DerivativeMap
 from ..spatial_types.spatial_types import (
     TransformationMatrix,

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -20,18 +20,18 @@ import rustworkx.visualization
 from lxml import etree
 from typing_extensions import List
 
-from .world_description import ActiveConnection, PassiveConnection, FixedConnection, Connection6DoF
+from .world_description.connections import ActiveConnection, PassiveConnection, FixedConnection, Connection6DoF
 from .world_description.connections import HasUpdateState, Has1DOFState
 from .world_description.degree_of_freedom import DegreeOfFreedom
 from .exceptions import (DuplicateViewError, AddingAnExistingViewError, ViewNotFoundError,
                                        AlreadyBelongsToAWorldError, )
 from .calculations.ik_solver import InverseKinematicsSolver
-from .datastructures import PrefixedName
+from .datastructures.prefixed_name import PrefixedName
 from .robots import AbstractRobot
 from .spatial_types import spatial_types as cas
 from .spatial_types.derivatives import Derivatives
 from .spatial_types.math import inverse_frame
-from .datastructures import NpMatrix4x4
+from .datastructures.types import NpMatrix4x4
 from .utils import IDGenerator, copy_lru_cache
 from .world_description.world_entity import (Body, Connection, View, KinematicStructureEntity, Region, GenericKinematicStructureEntity,
                                                            CollisionCheckingConfig, )

--- a/src/semantic_world/world_description/__init__.py
+++ b/src/semantic_world/world_description/__init__.py
@@ -1,13 +1,2 @@
-from .connections import (FixedConnection, PrismaticConnection, RevoluteConnection,
-                          Connection6DoF, ActiveConnection, PassiveConnection, OmniDrive)
-from .connection_factories import (ConnectionFactory, FixedConnectionFactory, PrismaticConnectionFactory,
-                                   RevoluteConnectionFactory)
-from .world_entity import Body, KinematicStructureEntity, Region, View, Connection, EnvironmentView
-from .geometry import (Mesh, TriangleMesh, BoundingBox, BoundingBoxCollection, Scale,
-                       Box, Sphere, Cylinder, Primitive, Shape)
-from .degree_of_freedom import DegreeOfFreedom
-from .world_modification import (WorldModelModificationBlock, WorldModelModification, UnknownWorldModification,
-                                 AddBodyModification, AddConnectionModification, AddDegreeOfFreedomModification)
-from .graph_of_convex_sets import GraphOfConvexSets, PoseOccupiedError
-from .world_state import WorldState
+
 

--- a/src/semantic_world/world_description/connection_factories.py
+++ b/src/semantic_world/world_description/connection_factories.py
@@ -12,7 +12,7 @@ from .connections import (
     Connection6DoF,
 )
 from .geometry import transformation_from_json, transformation_to_json
-from ..datastructures import PrefixedName
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types.spatial_types import TransformationMatrix
 from ..spatial_types.symbol_manager import symbol_manager
 from ..world import World

--- a/src/semantic_world/world_description/connections.py
+++ b/src/semantic_world/world_description/connections.py
@@ -8,10 +8,10 @@ import numpy as np
 
 from .. import spatial_types as cas
 from .degree_of_freedom import DegreeOfFreedom
-from ..datastructures import PrefixedName
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types.derivatives import DerivativeMap
 from ..spatial_types.math import quaternion_from_rotation_matrix
-from ..datastructures import NpMatrix4x4
+from ..datastructures.types import NpMatrix4x4
 from .world_entity import CollisionCheckingConfig, Connection
 
 if TYPE_CHECKING:

--- a/src/semantic_world/world_description/degree_of_freedom.py
+++ b/src/semantic_world/world_description/degree_of_freedom.py
@@ -5,7 +5,7 @@ from typing_extensions import Dict, Any
 
 from random_events.utils import SubclassJSONSerializer
 
-from ..datastructures import PrefixedName
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types import spatial_types as cas
 from ..spatial_types.derivatives import Derivatives, DerivativeMap
 from ..spatial_types.symbol_manager import symbol_manager

--- a/src/semantic_world/world_description/geometry.py
+++ b/src/semantic_world/world_description/geometry.py
@@ -20,10 +20,10 @@ from ..spatial_types import TransformationMatrix, Point3
 from ..spatial_types.spatial_types import Expression
 from ..spatial_types.symbol_manager import symbol_manager
 from ..utils import IDGenerator
-from ..datastructures import SpatialVariables
+from ..datastructures.variables import SpatialVariables
 
 if TYPE_CHECKING:
-    from ..world_description import KinematicStructureEntity
+    from ..world_description.world_entity import KinematicStructureEntity
 
 id_generator = IDGenerator()
 

--- a/src/semantic_world/world_description/graph_of_convex_sets.py
+++ b/src/semantic_world/world_description/graph_of_convex_sets.py
@@ -5,9 +5,9 @@ import logging
 import matplotlib.pyplot as plt
 
 from .geometry import BoundingBox, BoundingBoxCollection
-from ..datastructures import SpatialVariables
+from ..datastructures.variables import SpatialVariables
 from ..world import World
-from ..world_description import View, EnvironmentView
+from .world_entity import View, EnvironmentView
 
 logger = logging.getLogger(__name__)
 

--- a/src/semantic_world/world_description/world_entity.py
+++ b/src/semantic_world/world_description/world_entity.py
@@ -27,13 +27,13 @@ from trimesh.sample import sample_surface
 from trimesh.util import concatenate
 
 from .geometry import BoundingBoxCollection, BoundingBox, Shape
-from ..datastructures import PrefixedName
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types import spatial_types as cas
 from ..spatial_types.spatial_types import TransformationMatrix, Expression
 from ..utils import IDGenerator
 
 if TYPE_CHECKING:
-    from ..world_description import DegreeOfFreedom
+    from ..world_description.degree_of_freedom import DegreeOfFreedom
     from ..world import World
 
 id_generator = IDGenerator()

--- a/src/semantic_world/world_description/world_state.py
+++ b/src/semantic_world/world_description/world_state.py
@@ -2,7 +2,7 @@ from typing_extensions import MutableMapping, List, Dict
 
 import numpy as np
 
-from ..datastructures import PrefixedName
+from ..datastructures.prefixed_name import PrefixedName
 from ..spatial_types.derivatives import Derivatives
 
 

--- a/test/test_robots/test_world_pr2.py
+++ b/test/test_robots/test_world_pr2.py
@@ -6,7 +6,7 @@ import pytest
 from rustworkx import NoPathFound
 
 from semantic_world.adapters.urdf import URDFParser
-from semantic_world.world_description import OmniDrive, PrismaticConnection, RevoluteConnection
+from semantic_world.world_description.connections import OmniDrive, PrismaticConnection, RevoluteConnection
 from semantic_world.calculations.ik_solver import MaxIterationsException, UnreachableException
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.robots import PR2, KinematicChain

--- a/test/test_robots/test_world_two_arm_robot.py
+++ b/test/test_robots/test_world_two_arm_robot.py
@@ -1,6 +1,6 @@
 from semantic_world.testing import two_arm_robot_world
 from semantic_world.world import World
-from semantic_world.world_description import Body
+from semantic_world.world_description.world_entity import Body
 
 
 def test_simple_two_arm_robot(two_arm_robot_world: World):

--- a/test/test_ros/test_world_modifications.py
+++ b/test/test_ros/test_world_modifications.py
@@ -1,10 +1,10 @@
 import unittest
 
-from semantic_world.world_description import (
+from semantic_world.world_description.connection_factories import (
     ConnectionFactory,
     FixedConnectionFactory,
 )
-from semantic_world.world_description import (
+from semantic_world.world_description.connections import (
     FixedConnection,
     Connection6DoF,
     PrismaticConnection,
@@ -12,8 +12,8 @@ from semantic_world.world_description import (
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.spatial_types.spatial_types import Vector3
 from semantic_world.world import World
-from semantic_world.world_description import Body
-from semantic_world.world_description import (
+from semantic_world.world_description.world_entity import Body
+from semantic_world.world_description.world_modification import (
     WorldModelModificationBlock,
     UnknownWorldModification,
     AddBodyModification,

--- a/test/test_ros/test_world_synchronizer.py
+++ b/test/test_ros/test_world_synchronizer.py
@@ -8,12 +8,12 @@ from ormatic.utils import drop_database
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from semantic_world.world_description import Connection6DoF
+from semantic_world.world_description.connections import Connection6DoF
 from semantic_world.orm.ormatic_interface import Base, WorldMappingDAO
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.utils import rclpy_installed
 from semantic_world.world import World
-from semantic_world.world_description import Body
+from semantic_world.world_description.world_entity import Body
 
 if rclpy_installed():
     import rclpy

--- a/test/test_views/test_views.py
+++ b/test/test_views/test_views.py
@@ -7,9 +7,9 @@ import pytest
 from entity_query_language import an, entity, let, symbolic_mode, in_
 from numpy.ma.testutils import assert_equal
 
-from semantic_world.world_description import FixedConnection, PrismaticConnection
+from semantic_world.world_description.connections import FixedConnection, PrismaticConnection
 from semantic_world.reasoning.world_reasoner import WorldReasoner
-from semantic_world.world_description import KinematicStructureEntity
+from semantic_world.world_description.world_entity import KinematicStructureEntity
 
 try:
     from ripple_down_rules.user_interface.gui import RDRCaseViewer

--- a/test/test_worlds/test_gcs.py
+++ b/test/test_worlds/test_gcs.py
@@ -6,12 +6,12 @@ from random_events.interval import SimpleInterval
 from random_events.product_algebra import SimpleEvent
 
 from semantic_world.adapters.urdf import URDFParser
-from semantic_world.world_description import BoundingBox, BoundingBoxCollection
-from semantic_world.world_description import GraphOfConvexSets, PoseOccupiedError
+from semantic_world.world_description.geometry import BoundingBox, BoundingBoxCollection
+from semantic_world.world_description.graph_of_convex_sets import GraphOfConvexSets, PoseOccupiedError
 from semantic_world.spatial_types import Point3
 from semantic_world.datastructures.variables import SpatialVariables
 from semantic_world.world import World
-from semantic_world.world_description import Body
+from semantic_world.world_description.world_entity import Body
 
 
 class GCSTestCase(unittest.TestCase):

--- a/test/test_worlds/test_world.py
+++ b/test/test_worlds/test_world.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from semantic_world.world_description import PrismaticConnection, RevoluteConnection, Connection6DoF, FixedConnection
+from semantic_world.world_description.connections import PrismaticConnection, RevoluteConnection, Connection6DoF, FixedConnection
 from semantic_world.exceptions import AddingAnExistingViewError, DuplicateViewError, ViewNotFoundError
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.spatial_types.derivatives import Derivatives
@@ -9,7 +9,7 @@ from semantic_world.spatial_types.math import rotation_matrix_from_rpy
 from semantic_world.spatial_types.spatial_types import TransformationMatrix
 from semantic_world.spatial_types.symbol_manager import symbol_manager
 from semantic_world.testing import world_setup, pr2_world
-from semantic_world.world_description import View, Body
+from semantic_world.world_description.world_entity import View, Body
 
 
 def test_set_state(world_setup):


### PR DESCRIPTION
This pull request refactors imports throughout the codebase to use a more modular and explicit import structure, primarily by importing classes and functions from their specific submodules rather than from broader parent modules. This improves code clarity, maintainability, and reduces the risk of circular imports. Additionally, some unused or redundant imports are removed.

**Refactoring imports for modularity and clarity:**

* Changed imports throughout the codebase to import classes (such as `Body`, `View`, `Connection`, `DegreeOfFreedom`, `FixedConnection`, etc.) from their respective submodules (e.g., `world_entity`, `connections`, `degree_of_freedom`, `geometry`) instead of from the parent `world_description` module. [[1]](diffhunk://#diff-c388de46536446e3b367e1c2e3712550bdcfce4e4d5654509323fe9993b51499L91-R92) [[2]](diffhunk://#diff-c388de46536446e3b367e1c2e3712550bdcfce4e4d5654509323fe9993b51499L111-R112) [[3]](diffhunk://#diff-fcdc82718141eb32c216beb6c3d3cf44e0bccde5c6993371e042712705dd174aL38-R40) [[4]](diffhunk://#diff-fcdc82718141eb32c216beb6c3d3cf44e0bccde5c6993371e042712705dd174aL59-R61) [[5]](diffhunk://#diff-ff08710564d9726d078256447cfc969dd5e6b0981399d956ec974c208badadb6L11-R11) [[6]](diffhunk://#diff-eea05b061b4666111e7e51e7ec6de0c3d1a72d7144058e5c0a5dd94f5e4e3fb4L6-R12) [[7]](diffhunk://#diff-be1be163186b223f68ffca0c3c6e089de825840924745566804a63954ade3c8fL30-R32) [[8]](diffhunk://#diff-dbefe03012442f0f008680ebf4e927b88cad3468ca01a76d745facb58c88c45fL19-R21) [[9]](diffhunk://#diff-563abce1ab7b8bd4b58b5b73ea1c45a0ae6608b903c0fae071d889ce310971d9L9-R10) [[10]](diffhunk://#diff-803e7248230b137b04c90ebff6a4ad6d8c8732670676cc9dc5f996190dea3373L22-R22) [[11]](diffhunk://#diff-6077f0fdddafbc2157ad0377e8be4ace55f455d9d1d5c636c1b05c35077639a0L11-R17) [[12]](diffhunk://#diff-798421d9231c67d64f5977c3b4dd1136df029c1065d2a250975bc55b142d74b2L9-R10) [[13]](diffhunk://#diff-f3bc0da319b04d53f83489c67e6c7f9b37def0214442733db37c2a1f08b6290eL10-R11) [[14]](diffhunk://#diff-b0f7d30ef15a67ba76ad5e320429169089eb7bf73530da2fb968beea54894b7fL5-R9) [[15]](diffhunk://#diff-2e1de504fbc8f685e21af1bcfe798ddd0c5189b1bea686459bfcc5f21b051ec0L11-R19) [[16]](diffhunk://#diff-3ccc657040cacc69a7c48edcf3b7c6b9927f4247c5f23b0bc31d4c399e9bfe58L4-R4) [[17]](diffhunk://#diff-ac91763a9f4856c1624f0fd961eb89f30bafd0f778c157ca29718b38e0310536L7-R7) [[18]](diffhunk://#diff-51ba7a27e21af9b7e87e33d2517b87f0249025adb4fdff3c743dccf9b1c7f40cL6-R6) [[19]](diffhunk://#diff-c81c3755ca4649c5ace4bbf2cc7dea7054064d1f97d2440645dc2b9018843c4bL16-R16) [[20]](diffhunk://#diff-5fa6818d659c394cd1239bcdec0d3e5e89424bf79dc30006af2a183dfe6ac011L13-R13)

* Updated import paths for types such as `PrefixedName`, `NpMatrix4x4`, and `AnyMatrix4x4` to be imported from their specific submodules (`prefixed_name`, `types`) instead of the generic `datastructures` module. [[1]](diffhunk://#diff-fcdc82718141eb32c216beb6c3d3cf44e0bccde5c6993371e042712705dd174aL38-R40) [[2]](diffhunk://#diff-eea05b061b4666111e7e51e7ec6de0c3d1a72d7144058e5c0a5dd94f5e4e3fb4L6-R12) [[3]](diffhunk://#diff-be1be163186b223f68ffca0c3c6e089de825840924745566804a63954ade3c8fL30-R32) [[4]](diffhunk://#diff-dbefe03012442f0f008680ebf4e927b88cad3468ca01a76d745facb58c88c45fL19-R21) [[5]](diffhunk://#diff-563abce1ab7b8bd4b58b5b73ea1c45a0ae6608b903c0fae071d889ce310971d9L9-R10) [[6]](diffhunk://#diff-2e1de504fbc8f685e21af1bcfe798ddd0c5189b1bea686459bfcc5f21b051ec0L11-R19) [[7]](diffhunk://#diff-51ba7a27e21af9b7e87e33d2517b87f0249025adb4fdff3c743dccf9b1c7f40cL6-R6) [[8]](diffhunk://#diff-798421d9231c67d64f5977c3b4dd1136df029c1065d2a250975bc55b142d74b2L9-R10)

**Cleanup of unused or redundant imports:**

* Removed unused imports from `src/semantic_world/datastructures/__init__.py` and `src/semantic_world/reasoning/__init__.py` to prevent unnecessary namespace pollution. [[1]](diffhunk://#diff-6daf37b308fc28c347980fee6e87be9b89981c0e2800fd84d9b124f8823dcd05L1-L3) [[2]](diffhunk://#diff-6daf37b308fc28c347980fee6e87be9b89981c0e2800fd84d9b124f8823dcd05L1-L3)

These changes collectively make the codebase more modular and easier to maintain, while reducing the likelihood of import-related issues.