### PR TITLE
User guide fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ pip install -r requirements.txt
 
 
 # Tests
-The tests can be run using `pytest` after installing the package.
+The tests can be run with `pytest` directly in PyCharm or from the terminal after installing Semantic World as a python package.
 
 ```bash
+pip install -e .
 pytest test/
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ If you are interested in contributing, you can check out the source code from Gi
 git clone https://github.com/cram2/semantic_world.git
 ```
 
+### Development Dependencies
+
+```bash
+sudo apt install -y graphviz graphviz-dev
+pip install -r requirements.txt
+```
+
+
 # Tests
 The tests can be run using `pytest` after installing the package.
 

--- a/examples/loading_worlds.md
+++ b/examples/loading_worlds.md
@@ -15,7 +15,7 @@ jupyter:
 (loading-worlds)=
 # Loading worlds from files
 
-This tutorial shows how to load a world description from a file into a `World` object using the `MultiParser`.
+This tutorial shows how to load a world description from a file into a `World` object using the `URDFParser`.
 
 First, we need to compose the path to your world file.
 
@@ -30,13 +30,13 @@ apartment = os.path.join(get_semantic_world_directory_root(os.getcwd()), "resour
 
 ```
 
-Next we need to initialize a parser that reads this file. There are many parsers available. We will use the most capable one, the MultiParser.
+Next we need to initialize a parser that reads this file. There are many parsers available.
 
 ```python
-from semantic_world.adapters.multi_parser import MultiParser
-
-parser = MultiParser(apartment)
-world = parser.parse()
+from semantic_world.adapters.urdf import URDFParser  
+  
+parser = URDFParser.from_file(apartment)  
+world = parser.parse()  
 print(world)
 ```
 

--- a/examples/visualizing_worlds.md
+++ b/examples/visualizing_worlds.md
@@ -24,12 +24,12 @@ Let's load a world first to get started.
 import logging
 import os
 
-from semantic_world.adapters.multi_parser import MultiParser
+from semantic_world.adapters.urdf import URDFParser 
 from semantic_world.utils import get_semantic_world_directory_root
 
 logging.disable(logging.CRITICAL)
 apartment = os.path.join(get_semantic_world_directory_root(os.getcwd()), "resources", "urdf", "apartment.urdf")
-world = MultiParser(apartment).parse()
+world = URDFParser.from_file(apartment).parse()
 
 ```
 


### PR DESCRIPTION
I noticed some minor issues as I installed the semantic world in an almost fresh ubuntu 24.04 system and went through the user guide.
- I was missing the packages for graphviz that need to be installed via apt. They are needed to install the python requirements. Schould we list them as dependencies in the README?
- In the README I also added a clarifying statement for how to run the test, because it failed when one was blindly following the code instructions.
- When going through the user guide I noticed that the MultiParser can only be used when Multiverse is installed. I (and Luca) suggest to use the URDFParser to avoid the Multiverse dependency for the guide.