### PR TITLE
View factory refactor

### DIFF
--- a/.github/workflows/build_and_deploy_doc.yml
+++ b/.github/workflows/build_and_deploy_doc.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
     - main
+    - jupyter_renderer
 
     # If your git repository has the Jupyter Book within some-subfolder next to
     # unrelated files, you can make this run only if a file within that specific

--- a/.github/workflows/build_and_deploy_doc.yml
+++ b/.github/workflows/build_and_deploy_doc.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
     - main
-    - jupyter_renderer
 
     # If your git repository has the Jupyter Book within some-subfolder next to
     # unrelated files, you can make this run only if a file within that specific

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -70,7 +70,7 @@ When modifying your world, keep in mind that you need to open a `world.modify_wo
 ```python
 with world.modify_world():
     world.add_body(body)
-    
+
 from semantic_world.spatial_computations.raytracer import RayTracer
 rt = RayTracer(world)
 rt.update_scene()

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: myst
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 (creating-custom-bodies)=
 # Creating Custom Bodies

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -69,10 +69,9 @@ When modifying your world, keep in mind that you need to open a `world.modify_wo
 ```{code-cell} ipython2
 with world.modify_world():
     world.add_body(body)
-from semantic_world.spatial_computations.raytracer import RayTracer
-rt = RayTracer(world)
-rt.update_scene()
-rt.scene.show("jupyter")
+
+from semantic_world.world import visualize_current_world_snapshot_in_jupyter
+visualize_current_world_snapshot_in_jupyter(world)
 ```
 
 If you want to see your generated world, check out the [](visualizing-worlds) tutorial.

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -70,8 +70,10 @@ When modifying your world, keep in mind that you need to open a `world.modify_wo
 with world.modify_world():
     world.add_body(body)
 
-from semantic_world.world import visualize_current_world_snapshot
-visualize_current_world_snapshot(world)
+from semantic_world.spatial_computations.raytracer import RayTracer
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 If you want to see your generated world, check out the [](visualizing-worlds) tutorial.

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -17,7 +17,7 @@ jupyter:
 The tutorial demonstrates the creation of a body and its visual and collision information
 In our kinematic structure, each entity needs to have a unique name. For this we can use a simple datastructure called `PrefixedName`. You always need to provide a name, but the prefix is optional.
 
-```python
+```{code-cell} ipython2
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.spatial_types.spatial_types import TransformationMatrix, RotationMatrix
 from semantic_world.utils import get_semantic_world_directory_root
@@ -40,7 +40,7 @@ Supported Shapes are:
 - Cylinder
 - FileMesh/TriangleMesh
 
-```python
+```{code-cell} ipython2
 import os
 from semantic_world.spatial_types import Point3, Vector3
 from semantic_world.world_description.geometry import Box, Scale, Sphere, Cylinder, FileMesh, Color
@@ -67,7 +67,7 @@ body.visual = [mesh]
 
 When modifying your world, keep in mind that you need to open a `world.modify_world()` whenever you want to add or remove things to/from your world
 
-```python
+```{code-cell} ipython2
 with world.modify_world():
     world.add_body(body)
 from semantic_world.spatial_computations.raytracer import RayTracer

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -70,6 +70,11 @@ When modifying your world, keep in mind that you need to open a `world.modify_wo
 ```python
 with world.modify_world():
     world.add_body(body)
+    
+from semantic_world.spatial_computations.raytracer import RayTracer
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 If you want to see your generated world, check out the [](visualizing-worlds) tutorial.

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -3,7 +3,7 @@ jupyter:
   jupytext:
     text_representation:
       extension: .md
-      format_name: markdown
+      format_name: myst
       format_version: '1.3'
       jupytext_version: 1.17.3
   kernelspec:

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -70,8 +70,8 @@ When modifying your world, keep in mind that you need to open a `world.modify_wo
 with world.modify_world():
     world.add_body(body)
 
-from semantic_world.world import visualize_current_world_snapshot_in_jupyter
-visualize_current_world_snapshot_in_jupyter(world)
+from semantic_world.world import visualize_current_world_snapshot
+visualize_current_world_snapshot(world)
 ```
 
 If you want to see your generated world, check out the [](visualizing-worlds) tutorial.

--- a/examples/creating_custom_bodies.md
+++ b/examples/creating_custom_bodies.md
@@ -70,7 +70,6 @@ When modifying your world, keep in mind that you need to open a `world.modify_wo
 ```python
 with world.modify_world():
     world.add_body(body)
-
 from semantic_world.spatial_computations.raytracer import RayTracer
 rt = RayTracer(world)
 rt.update_scene()

--- a/examples/loading_worlds.md
+++ b/examples/loading_worlds.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 (loading-worlds)=
@@ -19,7 +18,7 @@ This tutorial shows how to load a world description from a file into a `World` o
 
 First, we need to compose the path to your world file.
 
-```python
+```{code-cell} ipython2
 import logging
 import os
 
@@ -32,12 +31,14 @@ apartment = os.path.join(get_semantic_world_directory_root(os.getcwd()), "resour
 
 Next we need to initialize a parser that reads this file. There are many parsers available.
 
-```python
-from semantic_world.adapters.urdf import URDFParser  
-  
-parser = URDFParser.from_file(apartment)  
-world = parser.parse()  
-print(world)
+```{code-cell} ipython2
+from semantic_world.adapters.urdf import URDFParser
+
+parser = URDFParser.from_file(apartment)
+world = parser.parse()
+
+from semantic_world.world import visualize_current_world_snapshot
+visualize_current_world_snapshot(world)
 ```
 
 This constructs a world you can visualize, interact and annotate. Be aware that worlds loaded from files have no semantic annotations and serve as purely kinematic models.

--- a/examples/loading_worlds.md
+++ b/examples/loading_worlds.md
@@ -1,14 +1,15 @@
 ---
-jupytext:
-  text_representation:
-    extension: .md
-    format_name: myst
-    format_version: 0.13
-    jupytext_version: 1.16.4
-kernelspec:
-  display_name: Python 3
-  language: python
-  name: python3
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.17.3
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
 ---
 
 (loading-worlds)=
@@ -18,7 +19,7 @@ This tutorial shows how to load a world description from a file into a `World` o
 
 First, we need to compose the path to your world file.
 
-```{code-cell} ipython2
+```python
 import logging
 import os
 
@@ -29,16 +30,15 @@ apartment = os.path.join(get_semantic_world_directory_root(os.getcwd()), "resour
 
 ```
 
-Next we need to initialize a parser that reads this file. There are many parsers available.
+Next we need to initialize a parser that reads this file. There are many parsers available. 
+To read this specific urdf file, the `https://github.com/code-iai/iai_maps/tree/ros-jazzy/` repository needs to be installed
+inside your ROS2 workspace.
 
-```{code-cell} ipython2
-from semantic_world.adapters.urdf import URDFParser
-
-parser = URDFParser.from_file(apartment)
-world = parser.parse()
-
-from semantic_world.world import visualize_current_world_snapshot
-visualize_current_world_snapshot(world)
+```python
+from semantic_world.adapters.urdf import URDFParser  
+  
+parser = URDFParser.from_file(apartment)  
+world = parser.parse()  
 ```
 
 This constructs a world you can visualize, interact and annotate. Be aware that worlds loaded from files have no semantic annotations and serve as purely kinematic models.

--- a/examples/persistence_of_annotated_worlds.md
+++ b/examples/persistence_of_annotated_worlds.md
@@ -1,16 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    default_lexer: ipython2
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 (persistence-of-annotated-worlds)=
@@ -29,7 +27,7 @@ Let's go into an example where we create a world, store it, retrieve and reconst
 
 First, let's load a world from a URDF file.
 
-```python
+```{code-cell} ipython2
 import logging
 import os
 
@@ -55,7 +53,7 @@ world = URDFParser.from_file(table).parse()
 
 Next, we create a semantic annotation that describes the table.
 
-```python
+```{code-cell} ipython2
 table_view = Table([b for b in world.bodies if "top" in str(b.name)][0])
 world.add_view(table_view)
 print(table_view)
@@ -63,7 +61,7 @@ print(table_view)
 
 Now, let's store the world to a database. For that, we need to convert it to its data access object which than can be stored in the database.
 
-```python
+```{code-cell} ipython2
 dao = to_dao(world)
 session.add(dao)
 session.commit()
@@ -71,7 +69,7 @@ session.commit()
 
 We can now query the database about the world and reconstruct it to the original instance. As you can see the semantic annotations are also available and fully working.
 
-```python
+```{code-cell} ipython2
 queried_world = session.scalars(select(WorldMappingDAO)).one()
 reconstructed_world = queried_world.from_dao()
 table = [view for view in reconstructed_world.views if isinstance(view, Table)][0]

--- a/examples/regions.md
+++ b/examples/regions.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 (regions)=
@@ -29,13 +28,14 @@ Used Concepts:
 
 First, let's create a simple table with one leg.
 
-```python
+```{code-cell} ipython2
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.spatial_types import TransformationMatrix
 from semantic_world.world import World
 from semantic_world.world_description.connections import FixedConnection, Connection6DoF
 from semantic_world.world_description.geometry import Box, Scale
 from semantic_world.world_description.world_entity import Body, Region
+from semantic_world.spatial_computations.raytracer import RayTracer
 
 world = World()
 
@@ -74,11 +74,14 @@ with world.modify_world():
         _world=world,
     )
     world.add_connection(leg_to_top)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 Next, we create a region describing the top of the table. We declare that the region is a very thin box that sits on top of the table-top.
 
-```python
+```{code-cell} ipython2
 table_surface = Region(
     name=PrefixedName("supporting surface of table"),
 )
@@ -94,17 +97,19 @@ Regions are connected the same way bodies are connected.
 Hence, you can specify how the regions move w. r. t. to a body or even another region.
 We will now say the the region moves exactly as the table top moves.
 
-```python
+```{code-cell} ipython2
 with world.modify_world():
     world.add_kinematic_structure_entity(table_surface)
     connection = FixedConnection(table_top, table_surface, _world=world)
     world.add_connection(connection)
-print(world.regions)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 We can now see that if we move the table, we also move the region.
 
-```python
+```{code-cell} ipython2
 print(table_surface.global_pose.to_position().to_np()[:3])
 
 with world.modify_world():

--- a/examples/regions.md
+++ b/examples/regions.md
@@ -74,9 +74,6 @@ with world.modify_world():
         _world=world,
     )
     world.add_connection(leg_to_top)
-rt = RayTracer(world)
-rt.update_scene()
-rt.scene.show("jupyter")
 ```
 
 Next, we create a region describing the top of the table. We declare that the region is a very thin box that sits on top of the table-top.
@@ -102,9 +99,7 @@ with world.modify_world():
     world.add_kinematic_structure_entity(table_surface)
     connection = FixedConnection(table_top, table_surface, _world=world)
     world.add_connection(connection)
-rt = RayTracer(world)
-rt.update_scene()
-rt.scene.show("jupyter")
+print(world.regions)
 ```
 
 We can now see that if we move the table, we also move the region.

--- a/examples/views.md
+++ b/examples/views.md
@@ -50,9 +50,10 @@ from semantic_world.world_description.geometry import Sphere, Scale
 from semantic_world.world_description.world_entity import View, Body
 from semantic_world.spatial_computations.raytracer import RayTracer
 
+
 world = DrawerFactory(
     name=PrefixedName("drawer"),
-    container_factory=ContainerFactory(name=PrefixedName("container")),
+    container_factory=ContainerFactory(name=PrefixedName("container"), direction=Direction.Z),
     handle_factory=HandleFactory(name=PrefixedName("handle")),
 ).create()
 

--- a/examples/views.md
+++ b/examples/views.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 (semantic_annotations)=
@@ -30,7 +29,7 @@ Used Concepts:
 
 First, let's create a world containing a drawer.
 
-```python
+```{code-cell} ipython2
 from dataclasses import dataclass
 from typing import List
 
@@ -49,7 +48,7 @@ from semantic_world.world import World
 from semantic_world.world_description.connections import Connection6DoF
 from semantic_world.world_description.geometry import Sphere, Scale
 from semantic_world.world_description.world_entity import View, Body
-
+from semantic_world.spatial_computations.raytracer import RayTracer
 
 world = DrawerFactory(
     name=PrefixedName("drawer"),
@@ -58,13 +57,16 @@ world = DrawerFactory(
 ).create()
 
 print(*world.views, sep="\n")
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 The annotations now proof useful when an agent needs to infer information from the world.
 For instance, an agent might want to open a drawer. Opening a drawer is done by grasping the drawer handle.
 Due to the semantic structure, it is easily possible to access this information for the agent by formulating a query like this
 
-```python
+```{code-cell} ipython2
 handles = an(entity(let("handle", Handle, world.views)))
 print(list(handles.evaluate()))
 ```
@@ -74,26 +76,31 @@ in the world. For instance, consider a world that has a second handle that is at
 shouldn't be used by the agent to open a drawer.
 
 
-```python
-
+```{code-cell} ipython2
 useless_handle = HandleFactory(name=PrefixedName("useless handle")).create()
+rt = RayTracer(useless_handle)
+rt.update_scene()
+rt.scene.show("jupyter")
 print(useless_handle.views)
+
 with world.modify_world():
     world.merge_world_at_pose(
         useless_handle, TransformationMatrix.from_xyz_rpy(x=1.0, y=1.0)
     )
-
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 If we now evaluate the handle query, we see that multiple options exist.
 
-```python
+```{code-cell} ipython2
 print(*list(an(entity(let("handle", Handle, world.views))).evaluate()), sep="\n")
 ```
 
 We can refine the handle the agent wants by saying it must belong to a drawer
 
-```python
+```{code-cell} ipython2
 drawer = let("drawer", Drawer, world.views)
 handle = let("handle", Handle, world.views)
 print(*list(an(entity(handle, drawer.handle == handle)).evaluate()), sep="\n")
@@ -105,7 +112,7 @@ Make sure you follow the (Liskov substitution principle)[https://en.wikipedia.or
 Views define what they relate to via their attribute types.
 For instance, we can make an Apple view that classifies a body as an apple.
 
-```python
+```{code-cell} ipython2
 @dataclass
 class Apple(View):
     """A simple custom view declaring that a Body is an Apple."""
@@ -139,11 +146,14 @@ with world.modify_world():
     world.add_view(apple_view)
 
 print(world.views)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 Views can become arbitrary complex. For instance, we can make a box of fruits.
 
-```python
+```{code-cell} ipython2
 @dataclass
 class FruitBox(View):
     box: Container
@@ -183,6 +193,9 @@ fruit_box = FruitBox(
 )
 world.add_view(fruit_box)
 print(f"Fruit box with {len(fruit_box.fruits)} fruits")
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 One great quality of this is that every other agent who imports your definitions of views in the world is now able

--- a/examples/visualizing_worlds.md
+++ b/examples/visualizing_worlds.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 (visualizing-worlds)=
@@ -57,3 +56,7 @@ rclpy.shutdown()
 ```
 
 The multiverse way relies on multiverse and is WIP. Do it faster giang.
+
+If you have followed the guide until here, you have probably noticed that we have used the `visualize_current_world_snapshot` function
+a few times. This method is a convenient way of visualizing a world inside a notebook, like in these guides, but it is not recommended 
+for normal usage.

--- a/examples/visualizing_worlds.md
+++ b/examples/visualizing_worlds.md
@@ -57,6 +57,6 @@ rclpy.shutdown()
 
 The multiverse way relies on multiverse and is WIP. Do it faster giang.
 
-If you have followed the guide until here, you have probably noticed that we have used the `visualize_current_world_snapshot` function
-a few times. This method is a convenient way of visualizing a world inside a notebook, like in these guides, but it is not recommended 
+If you have followed the guide until here, you have probably noticed that we have used the RayTracer to visualize the world 
+a few times. This is a convenient way of visualizing a world inside a notebook, like in these guides, but it is not recommended 
 for normal usage.

--- a/examples/world_state_manipulation.md
+++ b/examples/world_state_manipulation.md
@@ -42,7 +42,7 @@ from semantic_world.views.factories import (
 )
 from semantic_world.views.views import Drawer
 from semantic_world.world_description.degree_of_freedom import DegreeOfFreedom
-from semantic_world.world_description.geometry import Scale, Box
+from semantic_world.world_description.geometry import Scale, Box, Color
 from semantic_world.spatial_computations.raytracer import RayTracer
 
 drawer_factory = DrawerFactory(

--- a/examples/world_state_manipulation.md
+++ b/examples/world_state_manipulation.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 (world-state-manipulation)=
@@ -30,10 +29,8 @@ import threading
 import time
 
 import numpy as np
-import rclpy
 from entity_query_language import the, entity, let
 
-from semantic_world.adapters.viz_marker import VizMarkerPublisher
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.spatial_types.spatial_types import TransformationMatrix
 from semantic_world.views.factories import (
@@ -46,8 +43,8 @@ from semantic_world.views.factories import (
 from semantic_world.views.views import Drawer
 from semantic_world.world_description.degree_of_freedom import DegreeOfFreedom
 from semantic_world.world_description.geometry import Scale
+from semantic_world.world import visualize_current_world_snapshot_in_jupyter
 
-rclpy.init()
 
 drawer_factory = DrawerFactory(
     name=PrefixedName("drawer"),
@@ -72,16 +69,8 @@ dresser_factory = DresserFactory(
 )
 
 world = dresser_factory.create()
-```
 
-Next, we creat the visualizer.
-
-```python
-node = rclpy.create_node("semantic_world")
-thread = threading.Thread(target=rclpy.spin, args=(node,), daemon=True)
-thread.start()
-viz = VizMarkerPublisher(world=world, node=node)
-
+visualize_current_world_snapshot_in_jupyter(world)
 ```
 
 Let's get a reference to the drawer we built above.
@@ -98,9 +87,8 @@ drawer = the(
 We can update the drawer's state by altering the free variables position of its prismatic connection to the dresser.
 
 ```python
-time.sleep(1)
 drawer.container.body.parent_connection.position = 0.1
-time.sleep(1)
+visualize_current_world_snapshot_in_jupyter(world)
 ```
 
 Note that this only works in this simple way for connections that only have one degree of freedom. For multiple degrees of freedom you either have to set the entire transformation or use the world state directly.
@@ -113,6 +101,12 @@ from semantic_world.world_description.world_entity import Body
 with world.modify_world():
     old_root = world.root
     new_root = Body(name=PrefixedName("virtual root"))
+    
+    # Add a visual for the new root so we can see the change of position in the visualization
+    box_origin = TransformationMatrix.from_xyz_rpy(reference_frame=new_root)
+    box = Box(origin=box_origin, scale=Scale(0.1, 0.1, 0.1), color=Color(1., 0., 0., 1., ))
+    new_root.collision = [box]
+    
     world.add_body(new_root)
     root_T_dresser = Connection6DoF(new_root, old_root, _world=world)
     world.add_connection(root_T_dresser)
@@ -124,11 +118,10 @@ Now we can start moving the dresser everywhere and even rotate it.
 from semantic_world.world_description.world_entity import Connection
 
 free_connection = the(entity(connection := let("connection", type_=Connection, domain=world.connections), connection.parent == world.root)).evaluate()
-time.sleep(1)
+
 with world.modify_world():
     free_connection.origin_expression = TransformationMatrix.from_xyz_rpy(1., 1., 0, 0., 0., 0.5 * np.pi)
-time.sleep(1)
-
+visualize_current_world_snapshot_in_jupyter(world)
 ```
 
 The final way of manipulating the world state is the registry for all degrees of freedom, the {py:class}`semantic_world.world_description.world_state.WorldState`.
@@ -141,10 +134,5 @@ We can close the drawer again as follows:
 dof = the(entity(name := let("degree_of_freedom", type_=PrefixedName, domain=world.state.keys()), name.name == "drawer_container_connection")).evaluate()
 with world.modify_world():
     world.state[dof] = [0., 0, 0, 0.]
-time.sleep(1.)
-```
-
-```python
-node.destroy_node()
-rclpy.shutdown()
+visualize_current_world_snapshot_in_jupyter(world)
 ```

--- a/examples/world_state_manipulation.md
+++ b/examples/world_state_manipulation.md
@@ -24,7 +24,7 @@ Concepts Used:
 
 First, we create a dresser containing a single drawer using the respective factories.
 
-```python
+```{code-cell} ipython2
 import threading
 import time
 
@@ -43,7 +43,7 @@ from semantic_world.views.factories import (
 from semantic_world.views.views import Drawer
 from semantic_world.world_description.degree_of_freedom import DegreeOfFreedom
 from semantic_world.world_description.geometry import Scale
-from semantic_world.world import visualize_current_world_snapshot_in_jupyter
+from semantic_world.world import visualize_current_world_snapshot
 
 
 drawer_factory = DrawerFactory(
@@ -70,12 +70,12 @@ dresser_factory = DresserFactory(
 
 world = dresser_factory.create()
 
-visualize_current_world_snapshot_in_jupyter(world)
+visualize_current_world_snapshot(world)
 ```
 
 Let's get a reference to the drawer we built above.
 
-```python
+```{code-cell} ipython2
 drawer = the(
     entity(
         let("drawer", type_=Drawer, domain=world.views),
@@ -86,15 +86,15 @@ drawer = the(
 
 We can update the drawer's state by altering the free variables position of its prismatic connection to the dresser.
 
-```python
+```{code-cell} ipython2
 drawer.container.body.parent_connection.position = 0.1
-visualize_current_world_snapshot_in_jupyter(world)
+visualize_current_world_snapshot(world)
 ```
 
 Note that this only works in this simple way for connections that only have one degree of freedom. For multiple degrees of freedom you either have to set the entire transformation or use the world state directly.
 To show this we first create a new root for the world and make a free connection from the new root to the dresser.
 
-```python
+```{code-cell} ipython2
 from semantic_world.world_description.connections import Connection6DoF
 from semantic_world.world_description.world_entity import Body
 
@@ -114,14 +114,14 @@ with world.modify_world():
 
 Now we can start moving the dresser everywhere and even rotate it.
 
-```python
+```{code-cell} ipython2
 from semantic_world.world_description.world_entity import Connection
 
 free_connection = the(entity(connection := let("connection", type_=Connection, domain=world.connections), connection.parent == world.root)).evaluate()
 
 with world.modify_world():
     free_connection.origin_expression = TransformationMatrix.from_xyz_rpy(1., 1., 0, 0., 0., 0.5 * np.pi)
-visualize_current_world_snapshot_in_jupyter(world)
+visualize_current_world_snapshot(world)
 ```
 
 The final way of manipulating the world state is the registry for all degrees of freedom, the {py:class}`semantic_world.world_description.world_state.WorldState`.
@@ -130,9 +130,9 @@ The state is an array of 4 values: the position, velocity, acceleration and jerk
 Since it is an aggregation of all degree of freedoms existing in the world, it can be messy to access.
 We can close the drawer again as follows:
 
-```python
+```{code-cell} ipython2
 dof = the(entity(name := let("degree_of_freedom", type_=PrefixedName, domain=world.state.keys()), name.name == "drawer_container_connection")).evaluate()
 with world.modify_world():
     world.state[dof] = [0., 0, 0, 0.]
-visualize_current_world_snapshot_in_jupyter(world)
+visualize_current_world_snapshot(world)
 ```

--- a/examples/world_state_manipulation.md
+++ b/examples/world_state_manipulation.md
@@ -52,7 +52,7 @@ drawer_factory = DrawerFactory(
         direction=Direction.Z,
         scale=Scale(0.3, 0.3, 0.2),
     ),
-    handle_factory=HandleFactory(name=PrefixedName("drawer_handle")),
+    handle_factory=HandleFactory(name=PrefixedName("drawer_handle"))
 )
 drawer_transform = TransformationMatrix()
 
@@ -107,7 +107,7 @@ with world.modify_world():
     
     # Add a visual for the new root so we can see the change of position in the visualization
     box_origin = TransformationMatrix.from_xyz_rpy(reference_frame=new_root)
-    box = Box(origin=box_origin, scale=Scale(0.1, 0.1, 0.1), color=Color(1., 0., 0., 1., ))
+    box = Box(origin=box_origin, scale=Scale(0.1, 0.1, 0.1), color=Color(1., 0., 0., 1.))
     new_root.collision = [box]
     
     world.add_body(new_root)

--- a/examples/world_state_manipulation.md
+++ b/examples/world_state_manipulation.md
@@ -42,9 +42,8 @@ from semantic_world.views.factories import (
 )
 from semantic_world.views.views import Drawer
 from semantic_world.world_description.degree_of_freedom import DegreeOfFreedom
-from semantic_world.world_description.geometry import Scale
-from semantic_world.world import visualize_current_world_snapshot
-
+from semantic_world.world_description.geometry import Scale, Box
+from semantic_world.spatial_computations.raytracer import RayTracer
 
 drawer_factory = DrawerFactory(
     name=PrefixedName("drawer"),
@@ -70,7 +69,9 @@ dresser_factory = DresserFactory(
 
 world = dresser_factory.create()
 
-visualize_current_world_snapshot(world)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 Let's get a reference to the drawer we built above.
@@ -88,7 +89,9 @@ We can update the drawer's state by altering the free variables position of its 
 
 ```{code-cell} ipython2
 drawer.container.body.parent_connection.position = 0.1
-visualize_current_world_snapshot(world)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 Note that this only works in this simple way for connections that only have one degree of freedom. For multiple degrees of freedom you either have to set the entire transformation or use the world state directly.
@@ -121,7 +124,9 @@ free_connection = the(entity(connection := let("connection", type_=Connection, d
 
 with world.modify_world():
     free_connection.origin_expression = TransformationMatrix.from_xyz_rpy(1., 1., 0, 0., 0., 0.5 * np.pi)
-visualize_current_world_snapshot(world)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 The final way of manipulating the world state is the registry for all degrees of freedom, the {py:class}`semantic_world.world_description.world_state.WorldState`.
@@ -134,5 +139,7 @@ We can close the drawer again as follows:
 dof = the(entity(name := let("degree_of_freedom", type_=PrefixedName, domain=world.state.keys()), name.name == "drawer_container_connection")).evaluate()
 with world.modify_world():
     world.state[dof] = [0., 0, 0, 0.]
-visualize_current_world_snapshot(world)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```

--- a/examples/world_state_manipulation.md
+++ b/examples/world_state_manipulation.md
@@ -113,6 +113,9 @@ with world.modify_world():
     world.add_body(new_root)
     root_T_dresser = Connection6DoF(new_root, old_root, _world=world)
     world.add_connection(root_T_dresser)
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 Now we can start moving the dresser everywhere and even rotate it.

--- a/examples/world_structure_manipulation.md
+++ b/examples/world_structure_manipulation.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.17.3
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
 ---
 
 (world-structure-manipulation)=
@@ -31,7 +30,7 @@ Since the addition of a body to the world would, in most cases, violate the tree
 
 Let's create a simple world.
 
-```python
+```{code-cell} ipython2
 from semantic_world.world import World
 from semantic_world.world_description.world_entity import Body
 from semantic_world.world_description.degree_of_freedom import DegreeOfFreedom
@@ -41,6 +40,7 @@ from semantic_world.world_description.connections import (
 )
 from semantic_world.datastructures.prefixed_name import PrefixedName
 from semantic_world.spatial_types.spatial_types import Vector3
+from semantic_world.spatial_computations.raytracer import RayTracer
 
 world = World()
 
@@ -75,13 +75,15 @@ with world.modify_world():
 print(f"Bodies after additions: {[str(b.name) for b in world.bodies]}")
 print(f"Connections after additions: {[str(c.name) for c in world.connections]}")
 print(f"Number of DoFs after additions: {len(world.degrees_of_freedom)}")
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 Now we want to remove the RevoluteConnection. This will also remove its DoF if no other connection uses it.
 To keep the world a connected tree, we also have to remove the now-disconnected child body in the same block.
 
-```python
-
+```{code-cell} ipython2
 with world.modify_world():
     world.remove_connection(c_base_link)
     world.remove_kinematic_structure_entity(link)
@@ -90,13 +92,16 @@ with world.modify_world():
 print(f"Final bodies: {[str(b.name) for b in world.bodies]}")
 print(f"Final connections: {[str(c.name) for c in world.connections]}")
 print(f"Final number of DoFs: {len(world.degrees_of_freedom)}")
+rt = RayTracer(world)
+rt.update_scene()
+rt.scene.show("jupyter")
 ```
 
 Another world structure manipulation is the addition/removal of a DoF.
 However, most DoFs are managed by connections and hence should not be mangled with directly.
 If you ever feel the need to manage a degree of freedom manually you can do it like this:
 
-```python
+```{code-cell} ipython2
 with world.modify_world():
     dof = DegreeOfFreedom(name=PrefixedName("my_dof"))
     world.add_degree_of_freedom(dof)

--- a/examples/world_structure_manipulation.md
+++ b/examples/world_structure_manipulation.md
@@ -75,9 +75,6 @@ with world.modify_world():
 print(f"Bodies after additions: {[str(b.name) for b in world.bodies]}")
 print(f"Connections after additions: {[str(c.name) for c in world.connections]}")
 print(f"Number of DoFs after additions: {len(world.degrees_of_freedom)}")
-rt = RayTracer(world)
-rt.update_scene()
-rt.scene.show("jupyter")
 ```
 
 Now we want to remove the RevoluteConnection. This will also remove its DoF if no other connection uses it.
@@ -92,9 +89,6 @@ with world.modify_world():
 print(f"Final bodies: {[str(b.name) for b in world.bodies]}")
 print(f"Final connections: {[str(c.name) for c in world.connections]}")
 print(f"Final number of DoFs: {len(world.degrees_of_freedom)}")
-rt = RayTracer(world)
-rt.update_scene()
-rt.scene.show("jupyter")
 ```
 
 Another world structure manipulation is the addition/removal of a DoF.

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ ortools
 fbxloader
 coacd
 pymysql
+pyglet == 1.5.31

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -1909,7 +1909,7 @@ class World:
                 return True
         return False
 
-def visualize_current_world_snapshot(world: World) -> None:
+def visualize_current_world_snapshot_in_jupyter(world: World) -> None:
     """
     Visualizes the current state of the world.
 

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -1908,15 +1908,3 @@ class World:
             ):
                 return True
         return False
-
-def visualize_current_world_snapshot(world: World) -> None:
-    """
-    Visualizes the current state of the world.
-
-    :param world: The World instance to visualize.
-    """
-    from semantic_world.spatial_computations.raytracer import RayTracer
-
-    rt = RayTracer(world)
-    rt.update_scene()
-    rt.scene.show("jupyter")

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -1908,3 +1908,15 @@ class World:
             ):
                 return True
         return False
+
+def visualize_current_world_snapshot(world: World) -> None:
+    """
+    Visualizes the current state of the world.
+
+    :param world: The World instance to visualize.
+    """
+    from semantic_world.spatial_computations.raytracer import RayTracer
+
+    rt = RayTracer(world)
+    rt.update_scene()
+    rt.scene.show("jupyter")

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -897,7 +897,7 @@ class World:
                 other_views = [view for view in other.views]
                 for view in other_views:
                     other.remove_view(view)
-                    self.add_view(view)
+                    self.add_view(view, exists_ok=handle_duplicates)
 
             connection = root_connection or Connection6DoF(
                 parent=self_root, child=other_root, _world=self

--- a/src/semantic_world/world.py
+++ b/src/semantic_world/world.py
@@ -1909,7 +1909,7 @@ class World:
                 return True
         return False
 
-def visualize_current_world_snapshot_in_jupyter(world: World) -> None:
+def visualize_current_world_snapshot(world: World) -> None:
     """
     Visualizes the current state of the world.
 

--- a/test/test_factories/test_factories.py
+++ b/test/test_factories/test_factories.py
@@ -52,9 +52,27 @@ class TestFactories(unittest.TestCase):
         self.assertIsInstance(door.handle, Handle)
 
     def test_double_door_factory(self):
+        door_factory = DoorFactory(
+            name=PrefixedName("door"),
+            handle_factory=HandleFactory(name=PrefixedName("handle")),
+            handle_direction=Direction.Y,
+        )
+        door_transform = TransformationMatrix.from_xyz_rpy(y=-0.5)
+
+        door_factory2 = DoorFactory(
+            name=PrefixedName("door2"),
+            handle_factory=HandleFactory(name=PrefixedName("handle2")),
+            handle_direction=Direction.NEGATIVE_Y,
+        )
+        door_transform2 = TransformationMatrix.from_xyz_rpy(y=0.5)
+
+        door_factories = [door_factory, door_factory2]
+        door_transforms = [door_transform, door_transform2]
+
         factory = DoubleDoorFactory(
             name=PrefixedName("double_door"),
-            handle_factory=HandleFactory(name=PrefixedName("handle")),
+            door_factories=door_factories,
+            door_transforms=door_transforms
         )
         world = factory.create()
         door_views = world.get_views_by_type(Door)
@@ -136,20 +154,38 @@ class TestFactories(unittest.TestCase):
             handle_factory=HandleFactory(name=PrefixedName("handle")),
             handle_direction=Direction.Y,
         )
+        door_transform = TransformationMatrix.from_xyz_rpy(y=-0.5)
 
-        door_transform = TransformationMatrix()
+        door_factory2 = DoorFactory(
+            name=PrefixedName("door2"),
+            handle_factory=HandleFactory(name=PrefixedName("handle2")),
+            handle_direction=Direction.NEGATIVE_Y,
+        )
+        door_transform2 = TransformationMatrix.from_xyz_rpy(y=0.5)
+
+        door_factories = [door_factory, door_factory2]
+        door_transforms = [door_transform, door_transform2]
 
         double_door_factory = DoubleDoorFactory(
             name=PrefixedName("double_door"),
-            handle_factory=HandleFactory(name=PrefixedName("handle")),
+            door_factories=door_factories,
+            door_transforms=door_transforms
         )
         double_door_transform = TransformationMatrix()
+
+        single_door_factory = DoorFactory(
+            name=PrefixedName("single_door"),
+            handle_factory=HandleFactory(name=PrefixedName("single_door_handle")),
+            handle_direction=Direction.Y,
+        )
+        single_door_transform = TransformationMatrix.from_xyz_rpy(y=-1.5)
+
 
         factory = WallFactory(
             name=PrefixedName("wall"),
             scale=Scale(0.1, 4, 2),
-            door_transforms=[door_transform, double_door_transform],
-            door_factories=[door_factory, double_door_factory],
+            door_transforms=[single_door_transform, double_door_transform],
+            door_factories=[single_door_factory, double_door_factory],
         )
         world = factory.create()
         wall_views = world.get_views_by_type(Wall)

--- a/test/test_procthor/test_procthor.py
+++ b/test/test_procthor/test_procthor.py
@@ -163,8 +163,9 @@ class ProcTHORTestCase(unittest.TestCase):
         door_factory = procthor_door.get_factory()
 
         self.assertEqual(door_factory.name.name, "Doorway_Double_7_room1_room4")
-        self.assertEqual(door_factory.scale, Scale(0.03, 2.0, 2.1))
-        self.assertEqual(door_factory.one_door_scale, Scale(0.03, 1.0, 2.1))
+        self.assertEqual(len(door_factory.door_factories), 2)
+        self.assertEqual(len(door_factory.door_transforms), 2)
+        self.assertEqual(door_factory.door_factories[0].scale, Scale(0.03, 1.0, 2.1))
 
     def test_wall_creation(self):
         parser = ProcTHORParser(self.file_path, None)


### PR DESCRIPTION
I was looking to create a world factory for the apartment lab to test out how well that works. 
I noticed that cabinet, and potentially a lot more concepts (dishwasher comes to mind), will basically all have the same or a very similar factory method to our current dresser factory.
One potential solution for this could be creating a common super class, maybe something like "storage unit" or sth like that, but also i dont really like it as it already has a few issues i can think of before even starting to try it out.

One other solution I can think of is mixins, which is what this draft shows.
The mixins, for example "HasDoorFactory" would contain all the information needed to utilize a door factory, like adding it to the world at the correct place, adding joints etc etc.

Another solution could be to have the factories have knowledge needed how to merge their concept into a world, instead of just creating that concept in its own world.

Im unsure which of the latter two approaches is nicer, I started off with mixins, and then thought of the other approach half way through.

Id appreciate your input on which approach you think is better
