### PR TITLE
Fix: Make ConnectionFactory.from_connection work with subclasses

### DIFF
--- a/src/semantic_world/world_description/connection_factories.py
+++ b/src/semantic_world/world_description/connection_factories.py
@@ -47,7 +47,7 @@ class ConnectionFactory(HasGeneric[T], SubclassJSONSerializer, ABC):
 
     @classmethod
     def from_connection(cls, connection: Connection) -> Self:
-        for factory in recursive_subclasses(cls):
+        for factory in recursive_subclasses(cls) + [cls]:
             if factory.original_class() == connection.__class__:
                 return factory._from_connection(connection)
         raise ValueError(f"Unknown connection type: {connection.name}")


### PR DESCRIPTION
Calling `Connection6DoFFactory.from_connection` currently results in a ValueError. This PR fixes it by making sure the class itself is checked in the `from_connection` implementation of `ConnectionFactory`.