### PR TITLE
Feat: Add AddViewModification and RemoveViewModification

### DIFF
--- a/src/semantic_world/world_description/world_modification.py
+++ b/src/semantic_world/world_description/world_modification.py
@@ -3,25 +3,23 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, field
 
-from random_events.utils import SubclassJSONSerializer, recursive_subclasses
+from random_events.utils import SubclassJSONSerializer
 from typing_extensions import (
     List,
     Dict,
     Any,
     Self,
-    Optional,
     Callable,
-    ClassVar,
     TYPE_CHECKING,
 )
 
 from .connection_factories import ConnectionFactory
 from .degree_of_freedom import DegreeOfFreedom
-from .world_entity import Body, KinematicStructureEntity
+from .world_entity import KinematicStructureEntity, View
 from ..datastructures.prefixed_name import PrefixedName
 
 if TYPE_CHECKING:
-    from ..world import World, FunctionStack
+    from ..world import World
 
 
 @dataclass
@@ -235,6 +233,50 @@ class RemoveDegreeOfFreedomModification(WorldModelModification):
     @classmethod
     def _from_json(cls, data: Dict[str, Any]) -> Self:
         return cls(dof_name=PrefixedName.from_json(data["dof"]))
+
+
+@dataclass
+class AddViewModification(WorldModelModification):
+    view: View
+
+    @classmethod
+    def from_kwargs(cls, kwargs: Dict[str, Any]):
+        return cls(view=kwargs["view"])
+
+    def apply(self, world: World):
+        world.add_view(self.view)
+
+    def to_json(self):
+        return {
+            **super().to_json(),
+            "view": self.view.to_json(),
+        }
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any]) -> Self:
+        return cls(view=View.from_json(data["view"]))
+
+
+@dataclass
+class RemoveViewModification(WorldModelModification):
+    view: View
+
+    @classmethod
+    def from_kwargs(cls, kwargs: Dict[str, Any]):
+        return cls(view=kwargs["view"])
+
+    def apply(self, world: World):
+        world.remove_view(self.view)
+
+    def to_json(self):
+        return {
+            **super().to_json(),
+            "view": self.view.to_json(),
+        }
+
+    @classmethod
+    def _from_json(cls, data: Dict[str, Any]) -> Self:
+        return cls(view=View.from_json(data["view"]))
 
 
 @dataclass


### PR DESCRIPTION
Added AddViewModification and RemoveViewModification along with their `to_json` and `_from_json` methods. This includes letting the `View` class inherit from `SubclassJSONSerializer` and implementing the corresponding `to_json` and `_from_json` there too.

The json related methods on the `View` class should work for the vast majority of views. They currently assume that Views are only objects that contain references to other serializable objects such as `Body`, `PrefixedName` or other Views.

This is just supposed to be a draft and any feedback is welcome.